### PR TITLE
Fix selection bug on removeRow, removeColumn and removeTable

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -10,12 +10,14 @@ const plugins = [
     tablePlugin
 ];
 
-const NODES = {
-    table:      props => <table><tbody {...props.attributes}>{props.children}</tbody></table>,
-    table_row:  props => <tr {...props.attributes}>{props.children}</tr>,
-    table_cell: props => <td {...props.attributes}>{props.children}</td>,
-    paragraph:  props => <p {...props.attributes}>{props.children}</p>,
-    heading:    props => <h1 {...props.attributes}>{props.children}</h1>
+const schema = {
+    nodes: {
+        table:      props => <table><tbody {...props.attributes}>{props.children}</tbody></table>,
+        table_row:  props => <tr {...props.attributes}>{props.children}</tr>,
+        table_cell: props => <td {...props.attributes}>{props.children}</td>,
+        paragraph:  props => <p {...props.attributes}>{props.children}</p>,
+        heading:    props => <h1 {...props.attributes}>{props.children}</h1>
+    }
 };
 
 const Example = React.createClass({
@@ -29,10 +31,6 @@ const Example = React.createClass({
         this.setState({
             state: state
         });
-    },
-
-    renderNode: function(node) {
-        return NODES[node.type];
     },
 
     onInsertTable: function() {
@@ -121,7 +119,7 @@ const Example = React.createClass({
                     plugins={plugins}
                     state={state}
                     onChange={this.onChange}
-                    renderNode={this.renderNode}
+                    schema={schema}
                 />
             </div>
         );

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function EditTable(opts) {
      * Is the selection in a table
      */
     function isSelectionInTable(state) {
+        const { startKey } = state.selection;
+
+        if (!startKey) return false;
+
         const { startBlock } = state;
 
         // Only handle events in cells

--- a/lib/transforms/insertTable.js
+++ b/lib/transforms/insertTable.js
@@ -11,6 +11,10 @@ const createTable = require('../createTable');
  */
 function insertTable(opts, transform, columns = 2, rows = 2) {
     const { state } = transform;
+    const { startKey } = state.selection;
+
+    if (!startKey) return false;
+
     const { startBlock } = state;
 
     // Get text of current block

--- a/lib/transforms/removeColumn.js
+++ b/lib/transforms/removeColumn.js
@@ -36,6 +36,7 @@ function removeColumn(opts, transform, at) {
 
     // Replace the table
     return transform
+        .unsetSelection()
         .setNodeByKey(table.key, newTable);
 }
 

--- a/lib/transforms/removeRow.js
+++ b/lib/transforms/removeRow.js
@@ -26,7 +26,7 @@ function removeRow(opts, transform, at) {
     });
 
     return transform
-
+        .unsetSelection()
         // Replace the table
         .setNodeByKey(table.key, newTable);
 }

--- a/lib/transforms/removeTable.js
+++ b/lib/transforms/removeTable.js
@@ -16,6 +16,7 @@ function removeTable(opts, transform, at) {
     const { table } = pos;
 
     return transform
+        .unsetSelection()
         .removeNodeByKey(table.key);
 }
 


### PR DESCRIPTION
@SamyPesse After I use the plugin with newer version of slate, I cannot remove row, column and table because `setNode` method call by `setNodeByKey` replace state selection with an error, then it makes state startBlock failed, so I fixed it by unset the selection before `setNodeByKey` and check state selection `startKey` if it does not exist then do nothing which produce the same behavior with current demo.

I also update the example to newer slate version.