### PR TITLE
replace setNodeByKey by insertNodeByKey / removeNodeByKey

### DIFF
--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -49,32 +49,38 @@ function tablesContainOnlyRows(opts) {
         },
 
         validate(table) {
-            const rows = table.nodes.filter(isRow);
+            // Figure out invalid rows
+            const invalids = table.nodes.filterNot(isRow);
 
-            if (table.nodes.isEmpty() || rows.isEmpty()) {
-                // No rows
-                return {
-                    nodes: [makeEmptyRow()]
-                };
-            } else if (table.nodes.size === rows.size) {
-                // Only valid rows
+            // Figure out valid rows
+            const add = invalids.size === table.nodes.size ? [makeEmptyRow()] : [];
+
+            if (invalids.size === 0 && add.length === 0) {
                 return null;
-            } else {
-                // Keep only rows
-                return {
-                    nodes: rows
-                };
             }
+
+            return {
+                invalids,
+                add
+            };
         },
 
         /**
          * Replaces the node's children
          * @param {List<Nodes>} value.nodes
          */
-        normalize(transform, node, value) {
-            return transform.setNodeByKey(node.key, {
-                nodes: value.nodes
-            });
+        normalize(transform, node, {invalids = [], add = []}) {
+            // Remove invalids
+            transform = invalids.reduce((t, child) => {
+                return t.removeNodeByKey(child.key, { normalize: false });
+            }, transform);
+
+            // Add valids
+            transform = add.reduce((t, child) => {
+                return t.insertNodeByKey(node.key, 0, child);
+            }, transform);
+
+            return transform;
         }
     };
 }

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,4 +1,5 @@
 const Slate = require('slate');
+const { Range } = require('immutable');
 
 /**
  * Create a schema for tables
@@ -119,8 +120,8 @@ function rowsContainRequiredColumns(opts) {
             const rows = table.nodes.filter(isRow);
 
             // The number of column this table has
-            const columns = rows.reduce(function(columns, row) {
-                return Math.max(columns, countCells(row));
+            const columns = rows.reduce((count, row) => {
+                return Math.max(count, countCells(row));
             }, 1); // Min 1 column
 
 
@@ -129,44 +130,43 @@ function rowsContainRequiredColumns(opts) {
                 return null;
             }
             // else normalize, by padding with empty cells
+            return rows
+                .map(row => {
+                    const cells = countCells(row);
+                    const invalids = row.nodes.filterNot(isCell);
 
-            const normalizedRows = rows.map(function(row) {
-                let newCells = row.nodes;
+                    // Row is valid: right count of cells and no extra node
+                    if (invalids.size == 0 && cells === columns) {
+                        return null;
+                    }
 
-                // Complete missing columns
-                const missing = columns - row.nodes.count();
-                if (missing > 0) {
-                    const missingColumns = Array.from(Array(missing)).map(makeEmptyCell);
-                    newCells = newCells.concat(missingColumns);
-                }
-
-                // Replace invalid columns with empty cells
-                newCells = newCells.map(function fix(column) {
-                    return isCell(column)
-                        ? column
-                        : makeEmptyCell();
-                });
-
-                return row.set(
-                    'nodes',
-                    newCells
-                );
-            });
-
-            return {
-                toUpdate: normalizedRows
-            };
+                    // Otherwise, remove the invalids and append the missing cells
+                    return {
+                        row,
+                        invalids,
+                        add: (columns - cells)
+                    };
+                })
+                .filter(Boolean);
         },
 
         /**
          * Updates by key every given nodes
          * @param {List<Nodes>} value.toUpdate
          */
-        normalize(transform, node, value) {
-            return value.toUpdate.reduce(
-                (tr, node) => tr.setNodeByKey(node.key, node),
-                transform
-            );
+        normalize(transform, node, rows) {
+            return rows.reduce((tr, { row, invalids, add }) => {
+                tr = invalids.reduce((t, child) => {
+                    return t.removeNodeByKey(child.key, { normalize: false });
+                }, tr);
+
+                tr = Range(0, add).reduce(t => {
+                    const cell = makeEmptyCell();
+                    return t.insertNodeByKey(row.key, 0, cell, { normalize: false });
+                }, tr);
+
+                return tr;
+            }, transform);
         }
     };
 }

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -56,7 +56,7 @@ function tablesContainOnlyRows(opts) {
             // Figure out valid rows
             const add = invalids.size === table.nodes.size ? [makeEmptyRow()] : [];
 
-            if (invalids.size === 0 && add.length === 0) {
+            if (invalids.isEmpty() && add.length === 0) {
                 return null;
             }
 
@@ -136,7 +136,7 @@ function rowsContainRequiredColumns(opts) {
                     const invalids = row.nodes.filterNot(isCell);
 
                     // Row is valid: right count of cells and no extra node
-                    if (invalids.size == 0 && cells === columns) {
+                    if (invalids.isEmpty() && cells === columns) {
                         return null;
                     }
 

--- a/lib/onBackspace.js
+++ b/lib/onBackspace.js
@@ -1,4 +1,3 @@
-const Immutable = require('immutable');
 const Slate = require('slate');
 
 function onBackspace(event, data, state, opts) {
@@ -21,19 +20,20 @@ function onBackspace(event, data, state, opts) {
     event.preventDefault();
 
     const { blocks, focusBlock } = state;
-    const transform = blocks.reduce(function(transform, block) {
-        if (block.type !== opts.typeCell) {
-            return transform;
-        }
-
-        return transform.setNodeByKey(
-            block.key, {
-                nodes: Immutable.List([
-                    Slate.Text.create()
-                ])
+    const transform = blocks.reduce(
+        (tr, block) => {
+            if (block.type !== opts.typeCell) {
+                return transform;
             }
-        );
-    }, state.transform());
+
+            const cellRange = Slate.Selection.create()
+                .collapseToStartOf(block)
+                .moveToOffsets(0, block.length);
+
+            return tr.deleteAtRange(cellRange);
+        },
+        state.transform()
+    );
 
     // Clear selected cells
     return transform

--- a/lib/onBackspace.js
+++ b/lib/onBackspace.js
@@ -27,8 +27,7 @@ function onBackspace(event, data, state, opts) {
             }
 
             const cellRange = Slate.Selection.create()
-                .collapseToStartOf(block)
-                .moveToOffsets(0, block.length);
+                .moveToRangeOf(block);
 
             return tr.deleteAtRange(cellRange);
         },

--- a/lib/transforms/insertColumn.js
+++ b/lib/transforms/insertColumn.js
@@ -21,7 +21,7 @@ function insertColumn(opts, transform, at) {
         at = pos.getColumnIndex() + 1;
     }
 
-    table.nodes.forEach(function(row) {
+    table.nodes.forEach((row) => {
         const newCell = createCell(opts.typeCell);
         transform.insertNodeByKey(row.key, at, newCell);
     });

--- a/lib/transforms/insertColumn.js
+++ b/lib/transforms/insertColumn.js
@@ -21,25 +21,11 @@ function insertColumn(opts, transform, at) {
         at = pos.getColumnIndex() + 1;
     }
 
-    let rows = table.nodes;
-
-    // Add a new cell to each row
-    rows = rows.map(function(row) {
-        let cells = row.nodes;
+    table.nodes.forEach(function(row) {
         const newCell = createCell(opts.typeCell);
-
-        cells = cells.insert(at, newCell);
-
-        return row.merge({ nodes: cells });
+        transform.insertNodeByKey(row.key, at, newCell);
     });
 
-    // Update table
-    const newTable = table.merge({
-        nodes: rows
-    });
-
-    // Replace the table
-    transform = transform.setNodeByKey(table.key, newTable);
     // Update the selection (not doing can break the undo)
     return moveSelection(opts, transform, pos.getColumnIndex() + 1, pos.getRowIndex());
 }

--- a/lib/transforms/insertRow.js
+++ b/lib/transforms/insertRow.js
@@ -25,18 +25,10 @@ function insertRow(opts, transform, at, textGetter) {
         at = pos.getRowIndex() + 1;
     }
 
-    // Update table by inserting the row
-    const newTable = table.merge({
-        nodes: table.nodes
-            .insert(at, newRow)
-    });
-
     return transform
 
-        // Replace the table
-        .setNodeByKey(table.key, newTable)
+        .insertNodeByKey(table.key, at, newRow)
 
-        // Move selection to new row
         .collapseToEndOf(
             newRow.nodes.get(pos.getColumnIndex())
         );

--- a/lib/transforms/removeColumn.js
+++ b/lib/transforms/removeColumn.js
@@ -19,36 +19,28 @@ function removeColumn(opts, transform, at) {
         at = pos.getColumnIndex();
     }
 
-    let rows = table.nodes;
+    const rows = table.nodes;
 
     // Remove the cell from every row
     if (pos.getWidth() > 1) {
-        rows = rows.map(function(row) {
-            const cells = row.nodes.delete(at);
-
-            return row.merge({ nodes: cells });
+        rows.forEach((row) => {
+            const cell = row.nodes.get(at);
+            transform.removeNodeByKey(cell.key);
         });
     }
     // If last column, clear it instead
     else {
-        rows = rows.map(function(row) {
-            const clearedCells = row.nodes.map(
-                cell => cell.set('nodes', cell.nodes.clear())
-            );
-
-            return row.merge({ nodes: clearedCells });
+        rows.forEach((row) => {
+            row.nodes.forEach((cell) => {
+                cell.nodes.forEach((node) => {
+                    transform.removeNodeByKey(node.key);
+                });
+            });
         });
     }
 
-    // Update table
-    const newTable = table.merge({
-        nodes: rows
-    });
-
     // Replace the table
-    return transform
-        .unsetSelection()
-        .setNodeByKey(table.key, newTable);
+    return transform;
 }
 
 module.exports = removeColumn;

--- a/lib/transforms/removeRow.js
+++ b/lib/transforms/removeRow.js
@@ -19,30 +19,21 @@ function removeRow(opts, transform, at) {
         at = pos.getRowIndex();
     }
 
+    const row = table.nodes.get(at);
     // Update table by removing the row
-    let newTable;
     if (pos.getHeight() > 1) {
-        newTable = table.merge({
-            nodes: table.nodes.delete(at)
-        });
+        transform.removeNodeByKey(row.key);
     }
     // If last remaining row, clear it instead
     else {
-        newTable = table.merge({
-            nodes: table.nodes.map(function(row) {
-                return row.merge({
-                    nodes: row.nodes.map(
-                        cell => cell.set('nodes', cell.nodes.clear())
-                    )
-                });
-            })
+        row.nodes.forEach((cell) => {
+            cell.nodes.forEach((node) => {
+                transform.removeNodeByKey(node.key);
+            });
         });
     }
 
-    return transform
-        .unsetSelection()
-        // Replace the table
-        .setNodeByKey(table.key, newTable);
+    return transform;
 }
 
 module.exports = removeRow;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "serve-example": "http-server ./example/ -p 8080",
     "start": "npm run build-example; npm run serve-example",
     "deploy-example": "npm run build-example; gh-pages -d ./example",
-    "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --reporter=list --grep='slate-edit-list backspace-clear-cells'"
+    "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --bail --reporter=list"
   },
   "keywords": [
     "slate"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "dependencies": {
     "immutable": "^3.8.1",
-    "slate": "^0.14.10"
+    "slate": "GitbookIO/slate#26c6105c86994b2a19cf08dd6327a00d83bc497c"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -24,8 +24,7 @@
     "mocha": "^3.0.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
-    "read-metadata": "^1.0.0",
-    "slate": "^0.13.6"
+    "read-metadata": "^1.0.0"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "serve-example": "http-server ./example/ -p 8080",
     "start": "npm run build-example; npm run serve-example",
     "deploy-example": "npm run build-example; gh-pages -d ./example",
-    "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --bail --reporter=list"
+    "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --reporter=list --grep='slate-edit-list backspace-clear-cells'"
   },
   "keywords": [
     "slate"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "eslint": "^3.1.1",
-    "eslint-config-gitbook": "1.1.2",
+    "eslint-config-gitbook": "1.4.0",
     "expect": "^1.20.2",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",

--- a/tests/backspace-clear-cells/expected.yaml
+++ b/tests/backspace-clear-cells/expected.yaml
@@ -1,0 +1,59 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: ""
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: ""
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: ""
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: ""
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-clear-cells/input.yaml
+++ b/tests/backspace-clear-cells/input.yaml
@@ -28,7 +28,9 @@ nodes:
             type: table_cell
             nodes:
               - kind: text
+                # Start selection here, expected result is text empty [
                 text: "Col 0, Row 1"
+                key: "anchor"
           - kind: block
             type: table_cell
             nodes:
@@ -46,7 +48,9 @@ nodes:
             type: table_cell
             nodes:
               - kind: text
+                # ] End selection here, expected result is text empty
                 text: "Col 0, Row 2"
+                key: "focus"
           - kind: block
             type: table_cell
             nodes:

--- a/tests/backspace-clear-cells/input.yaml
+++ b/tests/backspace-clear-cells/input.yaml
@@ -1,0 +1,59 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-clear-cells/transform.js
+++ b/tests/backspace-clear-cells/transform.js
@@ -1,0 +1,19 @@
+module.exports = function(plugin, state) {
+    const blocks = state.document.filterDescendants(node => node.type == 'table_cell');
+    const blockStart = blocks.get(3);
+    const blockEnd = blocks.get(6);
+
+    const withCursor = state.transform()
+        .collapseToStartOf(blockStart)
+        .extendToEndOf(blockEnd)
+        .apply();
+
+    return plugin.onKeyDown(
+        {
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        { key: 'backspace' },
+        withCursor
+    );
+};

--- a/tests/backspace-clear-cells/transform.js
+++ b/tests/backspace-clear-cells/transform.js
@@ -1,7 +1,6 @@
 module.exports = function(plugin, state) {
-    const blocks = state.document.filterDescendants(node => node.type == 'table_cell');
-    const blockStart = blocks.get(3);
-    const blockEnd = blocks.get(6);
+    const blockStart = state.document.getDescendant('anchor');
+    const blockEnd = state.document.getDescendant('focus');
 
     const withCursor = state.transform()
         .collapseToStartOf(blockStart)

--- a/tests/backspace-collapsed/expected.yaml
+++ b/tests/backspace-collapsed/expected.yaml
@@ -1,0 +1,59 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-collapsed/input.yaml
+++ b/tests/backspace-collapsed/input.yaml
@@ -1,0 +1,63 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                # Start selection here, expected result is text empty [
+                text: "Col 0, Row 1"
+                key: "anchor"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                # ] End selection here, expected result is text empty
+                text: "Col 0, Row 2"
+                key: "focus"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-collapsed/transform.js
+++ b/tests/backspace-collapsed/transform.js
@@ -1,0 +1,16 @@
+module.exports = function(plugin, state) {
+    const blockStart = state.document.getDescendant('anchor');
+
+    const withCursor = state.transform()
+        .collapseToStartOf(blockStart)
+        .apply();
+
+    return plugin.onKeyDown(
+        {
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        { key: 'backspace' },
+        withCursor
+    );
+};

--- a/tests/backspace-same-block/expected.yaml
+++ b/tests/backspace-same-block/expected.yaml
@@ -1,0 +1,59 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-same-block/input.yaml
+++ b/tests/backspace-same-block/input.yaml
@@ -1,0 +1,60 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+                key: "anchor"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/backspace-same-block/transform.js
+++ b/tests/backspace-same-block/transform.js
@@ -1,0 +1,24 @@
+const expect = require('expect');
+
+module.exports = function(plugin, state) {
+    const blockStart = state.document.getDescendant('anchor');
+    const blockEnd = state.document.getDescendant('anchor');
+
+    const withCursor = state.transform()
+        .collapseToStartOf(blockStart)
+        .extendToEndOf(blockEnd)
+        .apply();
+
+    const result = plugin.onKeyDown(
+        {
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        { key: 'backspace' },
+        withCursor
+    );
+
+    expect(result).toBe(undefined);
+
+    return state;
+};

--- a/tests/schema-rows-require-same-columns-counts/expected.yaml
+++ b/tests/schema-rows-require-same-columns-counts/expected.yaml
@@ -46,17 +46,17 @@ nodes:
       - kind: block
         type: table_row
         nodes:
-          - kind: block
-            type: table_cell
-            nodes:
-              - kind: text
-                text: "Row 3, Col 1"
           # Invalid columns replace by empty cell
           - kind: block
             type: table_cell
             nodes:
               - kind: text
                 text: ""
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 3, Col 1"
           - kind: block
             type: table_cell
             nodes:

--- a/tests/schema-rows-require-same-columns-counts/transform.js
+++ b/tests/schema-rows-require-same-columns-counts/transform.js
@@ -2,5 +2,7 @@ const Slate = require('slate');
 
 module.exports = function(plugin, state) {
     const schema = new Slate.Schema(plugin.schema);
-    return state.normalize(schema);
+    return state.transform()
+        .normalizeWith(schema)
+        .apply();
 };

--- a/tests/schema-standard-table/transform.js
+++ b/tests/schema-standard-table/transform.js
@@ -2,5 +2,7 @@ const Slate = require('slate');
 
 module.exports = function(plugin, state) {
     const schema = new Slate.Schema(plugin.schema);
-    return state.normalize(schema);
+    return state.transform()
+        .normalizeWith(schema)
+        .apply();
 };

--- a/tests/schema-tables-contain-rows/transform.js
+++ b/tests/schema-tables-contain-rows/transform.js
@@ -2,5 +2,7 @@ const Slate = require('slate');
 
 module.exports = function(plugin, state) {
     const schema = new Slate.Schema(plugin.schema);
-    return state.normalize(schema);
+    return state.transform()
+        .normalizeWith(schema)
+        .apply();
 };


### PR DESCRIPTION
Hi!

A little PR to begin fixing #14. This is in wip state, setNodeByKey remains in 

```
lib/makeSchema.js
167:                (tr, node) => tr.setNodeByKey(node.key, node),

lib/onBackspace.js
29:        return transform.setNodeByKey(

lib/transforms/insertColumn.js
42:    transform = transform.setNodeByKey(table.key, newTable);

lib/transforms/insertRow.js
37:        .setNodeByKey(table.key, newTable)

lib/transforms/removeColumn.js
51:        .setNodeByKey(table.key, newTable);

lib/transforms/removeRow.js
45:        .setNodeByKey(table.key, newTable);
```

For the moment, this only fix the usage of setNodeByKey in lib/makeSchema.js for `tablesContainOnlyRow`