### PR TITLE
Fix/13 enfore table around rows cells

### DIFF
--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -11,9 +11,73 @@ const { Range } = require('immutable');
 function makeSchema(opts) {
     return {
         rules: [
+            cellsWithinTable(opts),
+            rowsWithinTable(opts),
             tablesContainOnlyRows(opts),
             rowsContainRequiredColumns(opts)
         ]
+    };
+}
+
+function cellsWithinTable(opts) {
+    return {
+        match(node) {
+            return (node.kind === 'document' || node.kind === 'block')
+                && node.type !== opts.typeRow;
+        },
+
+        // Find child cells nodes not in a row
+        validate(node) {
+            const cells = node.nodes.filter((n) => {
+                return n.type === opts.typeCell;
+            });
+
+            if (cells.isEmpty()) return;
+
+            return {
+                cells
+            };
+        },
+
+        // If any, wrap all cells in a row block
+        normalize(transform, node, { cells }) {
+            transform = cells.reduce((tr, cell) => {
+                return tr.wrapBlockByKey(cell.key, opts.typeRow, { normalize: false });
+            }, transform);
+
+            return transform;
+        }
+    };
+}
+
+function rowsWithinTable(opts) {
+    return {
+        match(node) {
+            return (node.kind === 'document' || node.kind === 'block')
+                && node.type !== opts.typeTable;
+        },
+
+        // Find child cells nodes not in a row
+        validate(node) {
+            const rows = node.nodes.filter((n) => {
+                return n.type === opts.typeRow;
+            });
+
+            if (rows.isEmpty()) return;
+
+            return {
+                rows
+            };
+        },
+
+        // If any, wrap all cells in a row block
+        normalize(transform, node, { rows }) {
+            transform = rows.reduce((tr, row) => {
+                return tr.wrapBlockByKey(row.key, opts.typeTable, { normalize: false });
+            }, transform);
+
+            return transform;
+        }
     };
 }
 

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -19,6 +19,14 @@ function makeSchema(opts) {
     };
 }
 
+/**
+ * Rule to enforce cells are always surrounded by a row.
+ *
+ * @param {String} opts.typeTable The type of table blocks
+ * @param {String} opts.typeRow The type of row blocks
+ * @param {String} opts.typeCell The type of cell blocks
+ * @return {Object} A rule to ensure cells are always surrounded by a row.
+ */
 function cellsWithinTable(opts) {
     return {
         match(node) {
@@ -50,6 +58,14 @@ function cellsWithinTable(opts) {
     };
 }
 
+/**
+ * Rule to enforce rows are always surrounded by a table.
+ *
+ * @param {String} opts.typeTable The type of table blocks
+ * @param {String} opts.typeRow The type of row blocks
+ * @param {String} opts.typeCell The type of cell blocks
+ * @return {Object} A rule to ensure rows are always surrounded by a table.
+ */
 function rowsWithinTable(opts) {
     return {
         match(node) {

--- a/tests/schema-rows-cells-within-tables/expected.yaml
+++ b/tests/schema-rows-cells-within-tables/expected.yaml
@@ -9,3 +9,16 @@ nodes:
         nodes:
           - kind: text
             text: "No rows"
+
+  # A cell without surrounding tr gets inserted within a table, and within a tr
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "No rows"

--- a/tests/schema-rows-cells-within-tables/expected.yaml
+++ b/tests/schema-rows-cells-within-tables/expected.yaml
@@ -1,0 +1,11 @@
+
+nodes:
+  # A row without surrounding table gets inserted within a table
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: text
+            text: "No rows"

--- a/tests/schema-rows-cells-within-tables/input.yaml
+++ b/tests/schema-rows-cells-within-tables/input.yaml
@@ -1,0 +1,9 @@
+
+nodes:
+  # A row without surrounding table gets inserted within a table
+  - kind: block
+    type: table_row
+    nodes:
+      - kind: text
+        text: "No rows"
+

--- a/tests/schema-rows-cells-within-tables/input.yaml
+++ b/tests/schema-rows-cells-within-tables/input.yaml
@@ -7,3 +7,10 @@ nodes:
       - kind: text
         text: "No rows"
 
+  # A cell without surrounding tr gets inserted within a table, and within a tr
+  - kind: block
+    type: table_cell
+    nodes:
+      - kind: text
+        text: "No rows"
+

--- a/tests/schema-rows-cells-within-tables/transform.js
+++ b/tests/schema-rows-cells-within-tables/transform.js
@@ -1,0 +1,8 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    return state.transform()
+        .normalizeWith(schema)
+        .apply();
+};


### PR DESCRIPTION
Hi!

Here's a PR to enforce cells / rows not surrounded by a table to get inserted with a surrounding table, and should fix #13 

A cell when pasted is surrounded by a row, which itself gets surrounded by a table.