### PR TITLE
Feature/15 table alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ Move the selection to a specific position in the table.
 `plugin.transforms.moveSelectionBy(transform: Transform, column: Number, row: Number) => Transform`
 
 Move the selection by the given amount of columns and rows.
+
+#### `transforms.setColumnAlign`
+
+`plugin.transforms.setColumnAlign(transform: Transform, align: String, at: Number) => Transform`
+
+Sets column alignment for a given column (`at`). `align` defaults to center,
+`at` is optional and defaults to current cursor position.

--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ Move the selection by the given amount of columns and rows.
 
 `plugin.transforms.setColumnAlign(transform: Transform, align: String, at: Number) => Transform`
 
-Sets column alignment for a given column (`at`). `align` defaults to center,
-`at` is optional and defaults to current cursor position.
+Sets column alignment for a given column (`at`), in the current table. `align`
+defaults to center, `at` is optional and defaults to current cursor position.

--- a/example/main.js
+++ b/example/main.js
@@ -14,7 +14,10 @@ const schema = {
     nodes: {
         table:      props => <table><tbody {...props.attributes}>{props.children}</tbody></table>,
         table_row:  props => <tr {...props.attributes}>{props.children}</tr>,
-        table_cell: props => <td {...props.attributes}>{props.children}</td>,
+        table_cell: (props) => {
+            let align = props.node.get('data').get('align') || 'left'
+            return <td style={{ textAlign: align }} {...props.attributes}>{props.children}</td>;
+        },
         paragraph:  props => <p {...props.attributes}>{props.children}</p>,
         heading:    props => <h1 {...props.attributes}>{props.children}</h1>
     }

--- a/example/main.js
+++ b/example/main.js
@@ -87,6 +87,15 @@ const Example = React.createClass({
         );
     },
 
+    onSetAlign: function (event, align) {
+        let { state } = this.state;
+
+        this.onChange(
+            tablePlugin.transforms.setColumnAlign(state.transform(), null, align)
+                .apply()
+        );
+    },
+
     renderNormalToolbar: function() {
         return (
             <div>
@@ -103,6 +112,10 @@ const Example = React.createClass({
                 <button onClick={this.onRemoveColumn}>Remove Column</button>
                 <button onClick={this.onRemoveRow}>Remove Row</button>
                 <button onClick={this.onRemoveTable}>Remove Table</button>
+                <br />
+                <button onClick={(e) => this.onSetAlign(e, 'left') }>Set align left</button>
+                <button onClick={(e) => this.onSetAlign(e, 'center') }>Set align center</button>
+                <button onClick={(e) => this.onSetAlign(e, 'right') }>Set align right</button>
             </div>
         );
     },

--- a/example/main.js
+++ b/example/main.js
@@ -94,7 +94,7 @@ const Example = React.createClass({
         let { state } = this.state;
 
         this.onChange(
-            tablePlugin.transforms.setColumnAlign(state.transform(), null, align)
+            tablePlugin.transforms.setColumnAlign(state.transform(), align)
                 .apply()
         );
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,12 @@ const KEY_BACKSPACE = 'backspace';
 const KEY_DOWN      = 'down';
 const KEY_UP        = 'up';
 
+const ALIGN = {
+    LEFT:   'left',
+    RIGHT:  'right',
+    CENTER: 'center'
+};
+
 /**
  * @param {String} opts.typeTable The type of table blocks
  * @param {String} opts.typeRow The type of row blocks
@@ -111,5 +117,8 @@ function EditTable(opts) {
         }
     };
 }
+
+// Expose align constants to the plugin
+EditTable.ALIGN = ALIGN;
 
 module.exports = EditTable;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ const removeColumn    = require('./transforms/removeColumn');
 const removeTable     = require('./transforms/removeTable');
 const moveSelection   = require('./transforms/moveSelection');
 const moveSelectionBy = require('./transforms/moveSelectionBy');
+const setColumnAlign  = require('./transforms/setColumnAlign');
 
 const onEnter       = require('./onEnter');
 const onTab         = require('./onTab');
@@ -105,7 +106,8 @@ function EditTable(opts) {
             removeColumn:    bindTransform(removeColumn),
             removeTable:     bindTransform(removeTable),
             moveSelection:   bindTransform(moveSelection),
-            moveSelectionBy: bindTransform(moveSelectionBy)
+            moveSelectionBy: bindTransform(moveSelectionBy),
+            setColumnAlign:  bindTransform(setColumnAlign)
         }
     };
 }

--- a/lib/transforms/setColumnAlign.js
+++ b/lib/transforms/setColumnAlign.js
@@ -17,20 +17,14 @@ function setColumnAlign(opts, transform, align = 'center', at) {
     const pos = TablePosition.create(state, startBlock);
     const { table } = pos;
 
-    // Figure out column position, defaults 0 position to 1, any other falsy
-    // values defaults to current column index
-    if (at === 0) {
-        at = 1;
-    } else if (!at) {
-        at = pos.getColumnIndex() + 1;
+    // Figure out column position
+    if (typeof at === 'undefined') {
+        at = pos.getColumnIndex();
     }
-
-    // and index, which is 0 based
-    const index = at - 1;
 
     table.nodes.forEach((row) => {
         row.nodes.forEach((cell, i) => {
-            if (i === index) {
+            if (i === at) {
                 transform.setNodeByKey(cell.key, {
                     data: Map({
                         align

--- a/lib/transforms/setColumnAlign.js
+++ b/lib/transforms/setColumnAlign.js
@@ -10,7 +10,7 @@ const { Map } = require('immutable');
  * @param {String} align
  * @return {Slate.Transform}
  */
-function setColumnAlign(opts, transform, at, align = 'center') {
+function setColumnAlign(opts, transform, align = 'center', at) {
     const { state } = transform;
     const { startBlock } = state;
 

--- a/lib/transforms/setColumnAlign.js
+++ b/lib/transforms/setColumnAlign.js
@@ -1,0 +1,46 @@
+const TablePosition = require('../TablePosition');
+const { Map } = require('immutable');
+
+/**
+ * Sets column alignment for a given column
+ *
+ * @param {Object} opts
+ * @param {Slate.Transform} transform
+ * @param {Number} at
+ * @param {String} align
+ * @return {Slate.Transform}
+ */
+function setColumnAlign(opts, transform, at, align = 'center') {
+    const { state } = transform;
+    const { startBlock } = state;
+
+    const pos = TablePosition.create(state, startBlock);
+    const { table } = pos;
+
+    // Figure out column position, defaults 0 position to 1, any other falsy
+    // values defaults to current column index
+    if (at === 0) {
+        at = 1;
+    } else if (!at) {
+        at = pos.getColumnIndex() + 1;
+    }
+
+    // and index, which is 0 based
+    const index = at - 1;
+
+    table.nodes.forEach((row) => {
+        row.nodes.forEach((cell, i) => {
+            if (i === index) {
+                transform.setNodeByKey(cell.key, {
+                    data: Map({
+                        align
+                    })
+                });
+            }
+        });
+    });
+
+    return transform;
+}
+
+module.exports = setColumnAlign;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "serve-example": "http-server ./example/ -p 8080",
     "start": "npm run build-example; npm run serve-example",
     "deploy-example": "npm run build-example; gh-pages -d ./example",
-    "test": "./node_modules/.bin/mocha ./tests/all.js --compilers js:babel-register --bail --reporter=list"
+    "test": "./node_modules/.bin/mocha ./tests/*.js --compilers js:babel-register --bail --reporter=list"
   },
   "keywords": [
     "slate"

--- a/tests/align-constants.js
+++ b/tests/align-constants.js
@@ -1,0 +1,13 @@
+
+const PluginEditTable = require('..');
+const expect = require('expect');
+
+describe('slate-edit-list', () => {
+    it('exposes align constants', () => {
+        expect(PluginEditTable.ALIGN).toEqual({
+            LEFT: 'left',
+            RIGHT: 'right',
+            CENTER: 'center'
+        });
+    });
+});

--- a/tests/set-column-align-center/expected.yaml
+++ b/tests/set-column-align-center/expected.yaml
@@ -1,0 +1,53 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: center
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: center
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: center
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"

--- a/tests/set-column-align-center/input.yaml
+++ b/tests/set-column-align-center/input.yaml
@@ -1,0 +1,48 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            key: '_cursor_'
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          # cursor is on second col, so this column gets center aligned
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"

--- a/tests/set-column-align-center/transform.js
+++ b/tests/set-column-align-center/transform.js
@@ -1,0 +1,7 @@
+module.exports = function(plugin, state) {
+    const cursorBlock = state.document.getDescendant('_cursor_');
+    const transform = state.transform();
+    state = transform.moveToRangeOf(cursorBlock).apply();
+
+    return plugin.transforms.setColumnAlign(state.transform()).apply();
+};

--- a/tests/set-column-align-left/expected.yaml
+++ b/tests/set-column-align-left/expected.yaml
@@ -1,0 +1,53 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: left
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: left
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            data:
+              align: left
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"

--- a/tests/set-column-align-left/input.yaml
+++ b/tests/set-column-align-left/input.yaml
@@ -1,0 +1,47 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          # at argument is set to 1, so this column gets left aligned
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"

--- a/tests/set-column-align-left/transform.js
+++ b/tests/set-column-align-left/transform.js
@@ -1,0 +1,3 @@
+module.exports = function(plugin, state) {
+    return plugin.transforms.setColumnAlign(state.transform(), 'left', 1).apply();
+};

--- a/tests/set-column-align-left/transform.js
+++ b/tests/set-column-align-left/transform.js
@@ -1,3 +1,3 @@
 module.exports = function(plugin, state) {
-    return plugin.transforms.setColumnAlign(state.transform(), 'left', 1).apply();
+    return plugin.transforms.setColumnAlign(state.transform(), 'left', 0).apply();
 };


### PR DESCRIPTION

Should fix #15 

This PR adds a new transform to set the column alignment for a given column, which gets added as a data property in the schema in the form of 

```
data: {
  align: 'left' | 'center' | 'right'
}
```