### PR TITLE
Add watchify to package.json build as watch-example

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
     "mocha": "^3.0.1",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
-    "read-metadata": "^1.0.0"
+    "read-metadata": "^1.0.0",
+    "watchify": "^3.7.0"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",
     "postpublish": "npm run deploy-example",
     "lint": "eslint ./",
     "build-example": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react ] ]",
+    "watch-example": "watchify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react ] ] -v",
     "serve-example": "http-server ./example/ -p 8080",
     "start": "npm run build-example; npm run serve-example",
     "deploy-example": "npm run build-example; gh-pages -d ./example",


### PR DESCRIPTION
This adds [watchify](https://github.com/substack/watchify) to package.json as watch-example script, for a slightly better development experience with the example.

Run with npm run watch-example