### PR TITLE
Update slate version and removed deprecations

### DIFF
--- a/lib/onTab.js
+++ b/lib/onTab.js
@@ -12,8 +12,8 @@ function selectAllText(transform) {
     const { startBlock } = state;
 
     return transform
-        .moveToOffsets(0)
-        .extendForward(startBlock.length);
+        .moveOffsetsTo(0)
+        .extend(startBlock.length);
 }
 
 /**

--- a/lib/transforms/moveSelection.js
+++ b/lib/transforms/moveSelection.js
@@ -30,7 +30,7 @@ function moveSelection(opts, transform, x, y) {
 
     return transform
         .collapseToEndOf(cell)
-        .moveToOffsets(startOffset);
+        .moveOffsetsTo(startOffset);
 }
 
 module.exports = moveSelection;

--- a/lib/transforms/removeTable.js
+++ b/lib/transforms/removeTable.js
@@ -16,7 +16,7 @@ function removeTable(opts, transform, at) {
     const { table } = pos;
 
     return transform
-        .unsetSelection()
+        .deselect()
         .removeNodeByKey(table.key);
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "0.16.22",
+    "slate": "^0.19.20",
     "watchify": "^3.7.0"
   },
   "scripts": {

--- a/tests/insert-table/transform.js
+++ b/tests/insert-table/transform.js
@@ -3,7 +3,7 @@ module.exports = function(plugin, state) {
     const transform = state.transform();
     state = transform
         .moveToRangeOf(cursorBlock)
-        .moveForward(6) // Cursor here: Before|After
+        .move(6) // Cursor here: Before|After
         .apply();
 
     return plugin.transforms.insertTable(state.transform())

--- a/tests/move-selection-by/transform.js
+++ b/tests/move-selection-by/transform.js
@@ -6,7 +6,7 @@ module.exports = function(plugin, state) {
     const transform = state.transform();
     state = transform
         .moveToRangeOf(cursorBlock)
-        .moveForward(offset)
+        .move(offset)
         .apply();
 
     state = plugin.transforms

--- a/tests/move-selection/transform.js
+++ b/tests/move-selection/transform.js
@@ -6,7 +6,7 @@ module.exports = function(plugin, state) {
     const transform = state.transform();
     state = transform
         .moveToRangeOf(cursorBlock)
-        .moveForward(offset)
+        .move(offset)
         .apply();
 
     state = plugin.transforms

--- a/tests/undo-insert-table/transform.js
+++ b/tests/undo-insert-table/transform.js
@@ -6,7 +6,7 @@ module.exports = function(plugin, state) {
 
     state = transform
         .moveToRangeOf(cursorBlock)
-        .moveForward(6) // Cursor here: Before|After
+        .move(6) // Cursor here: Before|After
         .apply();
 
     state = plugin.transforms.insertTable(state.transform()).apply();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,6 +2089,10 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
@@ -2867,6 +2871,10 @@ react-dom@^15.3.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react-portal@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.0.0.tgz#9304fce836e8a3216b22588f8dc91b447728f0ae"
+
 react@^15.3.0:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.1.tgz#498e918602677a3983cd0fd206dfe700389a0dd6"
@@ -3063,6 +3071,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+selection-is-backward@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/selection-is-backward/-/selection-is-backward-1.0.0.tgz#97a54633188a511aba6419fc5c1fa91b467e6be1"
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -3113,9 +3125,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate@0.16.22:
-  version "0.16.22"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.16.22.tgz#c08462f0f5ef74fa5e9c96b94863e4194d106673"
+slate@^0.19.20:
+  version "0.19.20"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.19.20.tgz#3d3a7f772b9fe12f8b2de6d646a44e5ab635f5d5"
   dependencies:
     cheerio "^0.22.0"
     debug "^2.3.2"
@@ -3125,7 +3137,10 @@ slate@0.16.22:
     get-window "^1.1.1"
     immutable "^3.8.1"
     is-empty "^1.0.0"
+    is-in-browser "^1.1.3"
     keycode "^2.1.2"
+    react-portal "^3.0.0"
+    selection-is-backward "^1.0.0"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:


### PR DESCRIPTION
Hello! I was using your plugin with the latest version of `slate` and found some annoying warnings about the use of deprecated transforms.

I updated the slate's version and substituted the deprecated transforms with the new ones.

Unfortunately two tests are not passing but I don't think they are related with the new transforms, probably just some other changes to slate core (they are both generated by a TypeError from the raw serializer).