### PR TITLE
Allow only inlines and text in cells

### DIFF
--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -35,8 +35,7 @@ function makeSchema(opts) {
 function noBlocksWithinCell(opts) {
     return {
         match(node) {
-            return (node.kind === 'block')
-                && node.type != opts.typeCell;
+            return node.kind == 'block' && node.type == opts.typeCell;
         },
 
         // Find nested blocks
@@ -48,10 +47,12 @@ function noBlocksWithinCell(opts) {
             return nestedBlocks.size > 0 ? nestedBlocks : null;
         },
 
-        // If any, wrap all cells in a row block
+        // If any, unwrap all nested blocks
         normalize(transform, node, nestedBlocks) {
             nestedBlocks.forEach(
-                block => transform.unwrapNodeByKey(block.key)
+                block => block.nodes.forEach((grandChild) => {
+                    transform.unwrapNodeByKey(grandChild.key);
+                })
             );
         }
     };

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -12,12 +12,48 @@ const createAlign = require('./createAlign');
 function makeSchema(opts) {
     return {
         rules: [
+            noBlocksWithinCell(opts),
             cellsWithinTable(opts),
             rowsWithinTable(opts),
             tablesContainOnlyRows(opts),
             rowsContainRequiredColumns(opts),
             tableContainAlignData(opts)
         ]
+    };
+}
+
+
+/**
+ * Rule to enforce cells only contain inlines or text.
+ * It unwrap blocks in cell blocks
+ *
+ * @param {String} opts.typeTable The type of table blocks
+ * @param {String} opts.typeRow The type of row blocks
+ * @param {String} opts.typeCell The type of cell blocks
+ * @return {Object} A rule to enforce cells only contain inlines or text.
+ */
+function noBlocksWithinCell(opts) {
+    return {
+        match(node) {
+            return (node.kind === 'block')
+                && node.type != opts.typeCell;
+        },
+
+        // Find nested blocks
+        validate(node) {
+            const nestedBlocks = node.nodes.filter(
+                child => child.kind === 'block'
+            );
+
+            return nestedBlocks.size > 0 ? nestedBlocks : null;
+        },
+
+        // If any, wrap all cells in a row block
+        normalize(transform, node, nestedBlocks) {
+            nestedBlocks.forEach(
+                block => transform.unwrapNodeByKey(block.key)
+            );
+        }
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.19.20",
+    "slate": "^0.20.6",
     "watchify": "^3.7.0"
   },
   "scripts": {

--- a/tests/schema-no-blocks-within-cells/expected.yaml
+++ b/tests/schema-no-blocks-within-cells/expected.yaml
@@ -1,0 +1,29 @@
+
+nodes:
+  - kind: block
+    type: table
+    data:
+        align:
+            - left
+            - left
+            - left
+    nodes:
+      # Row 1
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 1, Col 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 1, Col 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-cells/expected.yaml
+++ b/tests/schema-no-blocks-within-cells/expected.yaml
@@ -21,7 +21,14 @@ nodes:
             type: table_cell
             nodes:
               - kind: text
-                text: "Row 1, Col 2"
+                text: ""
+              - kind: inline
+                type: link
+                nodes:
+                  - kind: text
+                    text: "Row 1, Col 2"
+              - kind: text
+                text: ""
           - kind: block
             type: table_cell
             nodes:

--- a/tests/schema-no-blocks-within-cells/input.yaml
+++ b/tests/schema-no-blocks-within-cells/input.yaml
@@ -23,8 +23,11 @@ nodes:
           - kind: block
             type: table_cell
             nodes:
-              - kind: text
-                text: "Row 1, Col 2"
+              - kind: inline
+                type: link
+                nodes:
+                  - kind: text
+                    text: "Row 1, Col 2"
           - kind: block
             type: table_cell
             nodes:

--- a/tests/schema-no-blocks-within-cells/input.yaml
+++ b/tests/schema-no-blocks-within-cells/input.yaml
@@ -1,0 +1,32 @@
+
+nodes:
+  - kind: block
+    type: table
+    data:
+        align:
+            - left
+            - left
+            - left
+    nodes:
+      # Row 1
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: block
+                type: paragraph
+                nodes:
+                  - kind: text
+                    text: "Row 1, Col 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 1, Col 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-cells/transform.js
+++ b/tests/schema-no-blocks-within-cells/transform.js
@@ -1,0 +1,8 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    return state.transform()
+        .normalize(schema)
+        .apply();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,10 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -2898,7 +2902,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -2986,9 +2990,11 @@ react-dom@^15.3.0:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-portal@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.0.0.tgz#9304fce836e8a3216b22588f8dc91b447728f0ae"
+react-portal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.1.0.tgz#865c44fb72a1da106c649206936559ce891ee899"
+  dependencies:
+    prop-types "^15.5.8"
 
 react@^15.3.0:
   version "15.5.4"
@@ -3257,9 +3263,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate@^0.19.20:
-  version "0.19.20"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.19.20.tgz#3d3a7f772b9fe12f8b2de6d646a44e5ab635f5d5"
+slate@^0.20.6:
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.20.6.tgz#c9b7825ece8e6d26c16543fdbbd3b9999f3b3ac6"
   dependencies:
     cheerio "^0.22.0"
     debug "^2.3.2"
@@ -3270,8 +3276,10 @@ slate@^0.19.20:
     immutable "^3.8.1"
     is-empty "^1.0.0"
     is-in-browser "^1.1.3"
+    is-window "^1.0.2"
     keycode "^2.1.2"
-    react-portal "^3.0.0"
+    prop-types "^15.5.8"
+    react-portal "^3.1.0"
     selection-is-backward "^1.0.0"
     type-of "^2.0.1"
 


### PR DESCRIPTION
This plugin works only for table cells containing inlines/text (pressing enter create a new row, etc). It is not designed to have nested tables.

This PR adds a rule to unwrap potential blocks in cells.