### PR TITLE
New utils.getPosition() => TablePosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- New `utils.getPosition(state) => TablePosition` to know easily the current
+  position within a table.
+
 ## [0.10.1] - 2017-07-13
   [0.10.1]: https://github.com/GitbookIO/slate-edit-table/compare/0.10.0...0.10.1
 

--- a/README.md
+++ b/README.md
@@ -40,25 +40,31 @@ const plugins = [
 
 #### `utils.isSelectionInTable`
 
-`plugin.utils.isSelectionInTable(state: State) => Boolean`
+`plugin.utils.isSelectionInTable(state: State) => boolean`
 
-Return true if selection is inside a table.
+Return true if selection is inside a table cell.
+
+#### `utils.getPosition`
+
+`plugin.utils.getPosition(state: State) => TablePosition`
+
+Returns the detailed position in the current table. Throws if not in a table.
 
 #### `transforms.insertTable`
 
-`plugin.transforms.insertTable(transform: Transform, columns: Number?, rows: Number?) => Transform`
+`plugin.transforms.insertTable(transform: Transform, columns: ?number, rows: ?number) => Transform`
 
 Insert a new empty table.
 
 #### `transforms.insertRow`
 
-`plugin.transforms.insertRow(transform: Transform, at: Number?) => Transform`
+`plugin.transforms.insertRow(transform: Transform, at: ?number) => Transform`
 
 Insert a new row after the current one or at the specific index (`at`).
 
 #### `transforms.insertColumn`
 
-`plugin.transforms.insertColumn(transform: Transform, at: Number?) => Transform`
+`plugin.transforms.insertColumn(transform: Transform, at: ?number) => Transform`
 
 Insert a new column after the current one or at the specific index (`at`).
 
@@ -70,31 +76,76 @@ Remove current table.
 
 #### `transforms.removeRow`
 
-`plugin.transforms.removeRow(transform: Transform, at: Number?) => Transform`
+`plugin.transforms.removeRow(transform: Transform, at: ?number) => Transform`
 
 Remove current row or the one at a specific index (`at`).
 
 #### `transforms.removeColumn`
 
-`plugin.transforms.removeColumn(transform: Transform, at: Number?) => Transform`
+`plugin.transforms.removeColumn(transform: Transform, at: ?number) => Transform`
 
 Remove current column or the one at a specific index (`at`).
 
 #### `transforms.moveSelection`
 
-`plugin.transforms.moveSelection(transform: Transform, column: Number, row: Number) => Transform`
+`plugin.transforms.moveSelection(transform: Transform, column: number, row: number) => Transform`
 
 Move the selection to a specific position in the table.
 
 #### `transforms.moveSelectionBy`
 
-`plugin.transforms.moveSelectionBy(transform: Transform, column: Number, row: Number) => Transform`
+`plugin.transforms.moveSelectionBy(transform: Transform, column: number, row: number) => Transform`
 
 Move the selection by the given amount of columns and rows.
 
 #### `transforms.setColumnAlign`
 
-`plugin.transforms.setColumnAlign(transform: Transform, align: String, at: Number) => Transform`
+`plugin.transforms.setColumnAlign(transform: Transform, align: string, at: number) => Transform`
 
 Sets column alignment for a given column (`at`), in the current table. `align`
 defaults to center, `at` is optional and defaults to current cursor position.
+
+### TablePosition
+
+An instance of `TablePosition` represents a position within a table (row and column).
+You can get your current position in a table by using `plugin.utils.getPosition(state)`.
+
+#### `position.getWidth() => number`
+
+Returns the number of columns in the current table.
+
+#### `position.getHeight() => number`
+
+Returns the number of rows in the current table.
+
+#### `position.getRowIndex() => number`
+
+Returns the index of the current row in the table.
+
+#### `position.getColumnIndex() => number`
+
+Return the index of the current column in the table.
+
+#### `position.isFirstCell() => boolean`
+
+True if on first row and first column of the table
+
+#### `position.isLastCell() => boolean`
+
+True if on last row and last column of the table
+
+#### `position.isFirstRow() => boolean`
+
+True if on first row
+
+#### `position.isLastRow() => boolean`
+
+True if on last row
+
+#### `position.isFirstColumn() => boolean`
+
+True if on first column
+
+#### `position.isLastColumn() => boolean`
+
+True if on last column

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const onBackspace = require('./onBackspace');
 const onUpDown    = require('./onUpDown');
 const ALIGN       = require('./ALIGN');
 const makeSchema  = require('./makeSchema');
+const TablePosition = require('./TablePosition');
 
 const KEY_ENTER     = 'enter';
 const KEY_TAB       = 'tab';
@@ -43,6 +44,19 @@ function EditTable(opts) {
 
         // Only handle events in cells
         return (startBlock.type === opts.typeCell);
+    }
+
+    /**
+     * @param {State} state The current state
+     * @returns {TablePosition} The position of the selection start, in the current table
+     * @throws {Error} If the start of the selection is not in a table
+     */
+    function getPosition(state) {
+        if (!isSelectionInTable(state)) {
+            throw new Error('Not in a table');
+        }
+        const cell = state.startBlock;
+        return TablePosition.create(state, cell);
     }
 
     /**
@@ -96,7 +110,8 @@ function EditTable(opts) {
         schema,
 
         utils: {
-            isSelectionInTable
+            isSelectionInTable,
+            getPosition
         },
 
         transforms: {

--- a/tests/all.js
+++ b/tests/all.js
@@ -16,7 +16,9 @@ describe('slate-edit-list', function() {
         it(test, function() {
             const dir = path.resolve(__dirname, test);
             const input = readMetadata.sync(path.resolve(dir, 'input.yaml'));
-            const expected = readMetadata.sync(path.resolve(dir, 'expected.yaml'));
+            const expectedPath = path.resolve(dir, 'expected.yaml');
+            const expected = fs.existsSync(expectedPath) && readMetadata.sync(expectedPath);
+
             const runTransform = require(path.resolve(dir, 'transform.js'));
 
             const stateInput = Slate.Raw.deserialize(input, { terse: true });
@@ -24,7 +26,10 @@ describe('slate-edit-list', function() {
             const newState = runTransform(plugin, stateInput);
 
             const newDocJSon = Slate.Raw.serialize(newState, { terse: true });
-            expect(newDocJSon).toEqual(expected);
+
+            if (expected) {
+                expect(newDocJSon).toEqual(expected);
+            }
         });
     });
 });

--- a/tests/get-position/input.yaml
+++ b/tests/get-position/input.yaml
@@ -1,0 +1,60 @@
+
+nodes:
+  - kind: block
+    type: table
+    nodes:
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 0"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 0"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 1"
+          - kind: block
+            type: table_cell
+            key: '_cursor_' # start here
+            nodes:
+              - kind: text
+                text: "Col 1, Row 1"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 1"
+      - kind: block
+        type: table_row
+        nodes:
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 0, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 1, Row 2"
+          - kind: block
+            type: table_cell
+            nodes:
+              - kind: text
+                text: "Col 2, Row 2"

--- a/tests/get-position/transform.js
+++ b/tests/get-position/transform.js
@@ -1,0 +1,20 @@
+const expect = require('expect');
+
+module.exports = function(plugin, state) {
+    const cursorBlock = state.document.getDescendant('_cursor_');
+    const offset = 2;
+    const transform = state.transform();
+    state = transform
+        .moveToRangeOf(cursorBlock)
+        .move(offset)
+        .apply();
+
+    const position = plugin.utils.getPosition(state);
+
+    expect(position.getWidth()).toEqual(3);
+    expect(position.getHeight()).toEqual(3);
+    expect(position.getRowIndex()).toEqual(1);
+    expect(position.getColumnIndex()).toEqual(1);
+
+    return state;
+};


### PR DESCRIPTION
Fix #24 

It is now easier to insert rows or columns at the right index

To insert a row **before** the current cell, you can:

```js
const position = plugin.utils.getPosition(state);
const insertionIndex = position.getRowIndex() - 1;
const newState = plugin.transforms.insertRow(state.transform(), insertionIndex);
```