### PR TITLE
isSelectionInTable: Selection in the same table

### DIFF
--- a/lib/utils/isSelectionInTable.js
+++ b/lib/utils/isSelectionInTable.js
@@ -9,10 +9,26 @@ import type Options from '../options';
 function isSelectionInTable(opts: Options, value: Value): boolean {
     if (!value.selection.startKey) return false;
 
-    const { startBlock } = value;
+    const { startBlock, endBlock } = value;
 
     // Only handle events in cells
-    return startBlock.type === opts.typeCell;
+    if (startBlock === endBlock ) {
+      return startBlock.type === opts.typeCell;
+    }
+    if (startBlock.type !== opts.typeCell) {
+       return false;
+    }
+    if (endBlock.type !== opts.typeCell) {
+      return false;
+    }
+
+    // Ensure the startBlock and endBlock is in the same tableCell
+    const startRow = value.document.getParent(startBlock);
+    const endRow = value.document.getParent(endBlock)
+    if (startRow === endRow) {
+      return true
+    }
+    return (value.document.getParent(startRow) === value.document.getParent(endRow)) 
 }
 
 export default isSelectionInTable;


### PR DESCRIPTION
I think it is perhaps better if `isSelectionInTable` works when and only when the selection begins and ends in the same table.  Because table operations may have strange behaviors when it ends in another block.