### PR TITLE
Better Alignment and Range Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ const plugins = [
 
 Return true if selection is inside a table cell.
 
+#### `utils.isSelectionOutOfTable`
+
+`plugin.utils.isSelectionOutOfTable(value: Slate.Value) => boolean`
+
+Return true if selection starts and ends both outside any table.  (Notice: it is NOT the opposite value of `isSelectionInTable`)
+
 #### `utils.getPosition`
 
 `plugin.utils.getPosition(value: Slate.Value) => TablePosition`

--- a/example/main.js
+++ b/example/main.js
@@ -135,13 +135,13 @@ class Example extends React.Component<*, *> {
 
     render() {
         const { value } = this.state;
-        const isTable = tablePlugin.utils.isSelectionInTable(value);
+        const isInTable = tablePlugin.utils.isSelectionInTable(value);
+        const isOutTable = tablePlugin.utils.isSelectionOutOfTable(value);
 
         return (
             <div>
-                {isTable
-                    ? this.renderTableToolbar()
-                    : this.renderNormalToolbar()}
+                {isInTable ? this.renderTableToolbar(): null}
+                {isOutTable? this.renderNormalToolbar(): null}
                 <Editor
                     placeholder={'Enter some text...'}
                     renderNode={renderNode}

--- a/example/main.js
+++ b/example/main.js
@@ -53,6 +53,8 @@ function renderNode(props: NodeProps): React.Node {
 }
 
 class Example extends React.Component<*, *> {
+    submitChange: Function;
+    editorREF: Editor;
     state = {
         value: INITIAL_VALUE
     };
@@ -86,7 +88,7 @@ class Example extends React.Component<*, *> {
             </div>
         );
     }
-    setEditorComponent = ref => {
+    setEditorComponent = (ref: Editor) => {
         this.editorREF = ref;
         this.submitChange = ref.change;
     };

--- a/example/main.js
+++ b/example/main.js
@@ -61,12 +61,12 @@ class Example extends React.Component<*, *> {
 
     renderTableToolbar() {
         return (
-            <div onMouseLeave={this.onMouseLeave}>
-                <button onClick={this.onInsertColumn}>Insert Column</button>
-                <button onClick={this.onInsertRow}>Insert Row</button>
-                <button onClick={this.onRemoveColumn}>Remove Column</button>
-                <button onClick={this.onRemoveRow}>Remove Row</button>
-                <button onClick={this.onRemoveTable}>Remove Table</button>
+            <div>
+                <button onMouseDown={this.onInsertColumn}>Insert Column</button>
+                <button onMouseDown={this.onInsertRow}>Insert Row</button>
+                <button onMouseDown={this.onRemoveColumn}>Remove Column</button>
+                <button onMouseDown={this.onRemoveRow}>Remove Row</button>
+                <button onMouseDown={this.onRemoveTable}>Remove Table</button>
                 <br />
                 <button onClick={e => this.onSetAlign(e, 'left')}>
                     Set align left
@@ -97,15 +97,6 @@ class Example extends React.Component<*, *> {
         this.setState({
             value
         });
-    };
-    onMouseLeave = event => {
-        event.preventDefault();
-        this.submitChange(change =>
-            change
-                .setOperationFlag('save', false)
-                .focus()
-                .setOperationFlag('save', true)
-        );
     };
 
     onInsertTable = event => {

--- a/lib/changes/insertColumn.js
+++ b/lib/changes/insertColumn.js
@@ -30,17 +30,18 @@ function insertColumn(
 
     // Insert the new cell
     table.nodes.forEach(row => {
-        const newCell = createCell(opts.typeCell);
+        let newCell = createCell(opts.typeCell);
+        newCell = newCell.setIn(['data', 'textAlign'], ALIGN.DEFAULT);
         change.insertNodeByKey(row.key, at, newCell, { normalize: false });
     });
 
     // Update alignment
-    let align = table.data.get('align');
-    align = List(align)
+    let presetAlign = table.data.get('presetAlign');
+    presetAlign = List(presetAlign)
         .insert(at, columnAlign)
         .toArray();
     change.setNodeByKey(table.key, {
-        data: table.data.set('align', align)
+        data: table.data.set('presetAlign', presetAlign)
     });
 
     // Update the selection (not doing can break the undo)

--- a/lib/changes/insertRow.js
+++ b/lib/changes/insertRow.js
@@ -3,6 +3,7 @@ import { type Change } from 'slate';
 
 import { TablePosition, createRow } from '../utils';
 import type Options from '../options';
+import getAdjustedRow from '../helpers/getAdjustedRow';
 
 /**
  * Insert a new row in current table
@@ -21,7 +22,9 @@ function insertRow(
 
     // Create a new row with the right count of cells
     const firstRow = table.nodes.get(0);
-    const newRow = createRow(opts, firstRow.nodes.size, textGetter);
+    const presetAlign = table.data.get('presetAlign');
+    let newRow = createRow(opts, firstRow.nodes.size, textGetter);
+    newRow = getAdjustedRow(newRow, presetAlign);
 
     if (typeof at === 'undefined') {
         at = pos.getRowIndex() + 1;

--- a/lib/changes/removeColumn.js
+++ b/lib/changes/removeColumn.js
@@ -29,12 +29,12 @@ function removeColumn(opts: Options, change: Change, at: number): Change {
         });
 
         // Update alignment
-        let align = table.data.get('align');
-        align = List(align)
+        let presetAlign = table.data.get('presetAlign');
+        presetAlign = List(presetAlign)
             .delete(at)
             .toArray();
         change.setNodeByKey(table.key, {
-            data: table.data.set('align', align)
+            data: table.data.set('presetAlign', presetAlign)
         });
     } else {
         // If last column, clear text in cells instead

--- a/lib/changes/setColumnAlign.js
+++ b/lib/changes/setColumnAlign.js
@@ -4,6 +4,7 @@ import { type Change } from 'slate';
 import { TablePosition, createAlign } from '../utils';
 import ALIGN from '../ALIGN';
 import type Options from '../options';
+import setTableAlign from './setTableAlign';
 
 /**
  * Sets column alignment for a given column
@@ -11,7 +12,7 @@ import type Options from '../options';
 function setColumnAlign(
     opts: Options,
     change: Change,
-    align: string = ALIGN.DEFAULT,
+    cellAlign: string = ALIGN.DEFAULT,
     at: number
 ): Change {
     const { value } = change;
@@ -25,14 +26,9 @@ function setColumnAlign(
         at = pos.getColumnIndex();
     }
 
-    const newAlign = createAlign(pos.getWidth(), table.data.get('align'));
-    newAlign[at] = align;
-
-    change.setNodeByKey(table.key, {
-        data: table.data.set('align', newAlign)
-    });
-
-    return change;
+    const newAlign = createAlign(pos.getWidth(), table.data.get('presetAlign'));
+    newAlign[at] = cellAlign;
+    return setTableAlign(opts, change, table, newAlign);
 }
 
 export default setColumnAlign;

--- a/lib/changes/setTableAlign.js
+++ b/lib/changes/setTableAlign.js
@@ -1,0 +1,35 @@
+// @flow
+import { type Change, type Block } from 'slate';
+import type Options from '../options';
+import getAdjustedRow from '../helpers/getAdjustedRow';
+
+/**
+ * Sets column alignment for a given column
+ */
+function setTableAlign(
+    opts: Options,
+    change: Change,
+    table: Block,
+    presetAlign: Array<string>
+): Change {
+    const nextTable = table
+        .set('nodes', table.nodes.map(row => getAdjustedRow(row, presetAlign)))
+        .setIn(['data', 'presetAlign'], presetAlign);
+
+    // To restore selection, the following code function like change.replaceNodeByKey(table.key, nextTable).focus();
+    change.setNodeByKey(table.key, { data: nextTable.data });
+    table.nodes.forEach((row, rowIndex) => {
+        row.nodes.forEach((cell, cellIndex) => {
+            const nextCell = nextTable.nodes.get(rowIndex).nodes.get(cellIndex);
+            if (nextCell === cell) {
+                return cellIndex;
+            }
+            change.setNodeByKey(cell.key, { data: nextCell.data });
+            return cellIndex;
+        });
+        return rowIndex;
+    });
+
+    return change;
+}
+export default setTableAlign;

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,7 +10,7 @@ import {
     moveSelectionBy,
     setColumnAlign
 } from './changes';
-import { isSelectionInTable, getPosition } from './utils';
+import { isSelectionInTable, isSelectionOutOfTable, getPosition } from './utils';
 import { schema, validateNode } from './validation';
 
 import ALIGN from './ALIGN';
@@ -34,6 +34,7 @@ function core(optionsParam: Options | OptionsFormat): Object {
 
         utils: {
             isSelectionInTable: isSelectionInTable.bind(null, opts),
+            isSelectionOutOfTable: isSelectionOutOfTable.bind(null, opts),
             getPosition: getPosition.bind(null, opts)
         },
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,7 +10,11 @@ import {
     moveSelectionBy,
     setColumnAlign
 } from './changes';
-import { isSelectionInTable, isSelectionOutOfTable, getPosition } from './utils';
+import {
+    isSelectionInTable,
+    isSelectionOutOfTable,
+    getPosition
+} from './utils';
 import { schema, validateNode } from './validation';
 
 import ALIGN from './ALIGN';

--- a/lib/helpers/getAdjustedRow.js
+++ b/lib/helpers/getAdjustedRow.js
@@ -1,0 +1,21 @@
+// @flow
+import { type Block } from 'slate';
+
+function getAdjustedRow(row: Block, presetAlign?: Array<string>) {
+    if (!presetAlign) {
+        return row;
+    }
+    const nodes = row.nodes;
+    const nextRow = row.set(
+        'nodes',
+        nodes.map((cell, index) => {
+            if (cell.data.get('textAlign') === presetAlign[index]) {
+                return cell;
+            }
+            return cell.setIn(['data', 'textAlign'], presetAlign[index]);
+        })
+    );
+    return nextRow;
+}
+
+export default getAdjustedRow;

--- a/lib/helpers/getAdjustedRow.js
+++ b/lib/helpers/getAdjustedRow.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Block } from 'slate';
 
-function getAdjustedRow(row: Block, presetAlign?: Array<string>) {
+function getAdjustedRow(row: Block, presetAlign: Array<string>) {
     if (!presetAlign) {
         return row;
     }

--- a/lib/utils/createTable.js
+++ b/lib/utils/createTable.js
@@ -6,6 +6,7 @@ import type Options from '../options';
 
 import createRow from './createRow';
 import createAlign from './createAlign';
+import getAdjustedRow from '../helpers/getAdjustedRow';
 
 /**
  * Create a table
@@ -16,7 +17,7 @@ function createTable(
     rows: number,
     textGetter?: (row: number, column: number) => string
 ): Block {
-    const rowNodes = Range(0, rows)
+    let rowNodes = Range(0, rows)
         .map(i =>
             createRow(
                 opts,
@@ -25,13 +26,14 @@ function createTable(
             )
         )
         .toList();
-    const align = createAlign(columns);
+    const presetAlign = createAlign(columns);
+    rowNodes = rowNodes.map(row => getAdjustedRow(row, presetAlign));
 
     return Block.create({
         type: opts.typeTable,
         nodes: rowNodes,
         data: {
-            align
+            presetAlign
         }
     });
 }

--- a/lib/utils/createTable.js
+++ b/lib/utils/createTable.js
@@ -17,7 +17,8 @@ function createTable(
     rows: number,
     textGetter?: (row: number, column: number) => string
 ): Block {
-    let rowNodes = Range(0, rows)
+    const presetAlign = createAlign(columns);
+    const rowNodes = Range(0, rows)
         .map(i =>
             createRow(
                 opts,
@@ -25,9 +26,8 @@ function createTable(
                 textGetter ? textGetter.bind(null, i) : undefined
             )
         )
-        .toList();
-    const presetAlign = createAlign(columns);
-    rowNodes = rowNodes.map(row => getAdjustedRow(row, presetAlign));
+        .toList()
+        .map(row => getAdjustedRow(row, presetAlign));
 
     return Block.create({
         type: opts.typeTable,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,6 @@
 import getPosition from './getPosition';
 import isSelectionInTable from './isSelectionInTable';
+import isSelectionOutOfTable from "./isSelectionOutOfTable";
 import TablePosition from './TablePosition';
 
 import createAlign from './createAlign';
@@ -10,9 +11,10 @@ import createTable from './createTable';
 export {
     getPosition,
     isSelectionInTable,
+    isSelectionOutOfTable,
     TablePosition,
     createAlign,
     createCell,
     createRow,
-    createTable
+    createTable,
 };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,6 @@
 import getPosition from './getPosition';
 import isSelectionInTable from './isSelectionInTable';
-import isSelectionOutOfTable from "./isSelectionOutOfTable";
+import isSelectionOutOfTable from './isSelectionOutOfTable';
 import TablePosition from './TablePosition';
 
 import createAlign from './createAlign';
@@ -16,5 +16,5 @@ export {
     createAlign,
     createCell,
     createRow,
-    createTable,
+    createTable
 };

--- a/lib/utils/isSelectionOutOfTable.js
+++ b/lib/utils/isSelectionOutOfTable.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { Value } from 'slate';
+import type Options from '../options';
+
+/**
+ * Is the selection in a table
+ */
+function isSelectionOutOfTable(opts: Options, value: Value): boolean {
+    if (!value.selection.startKey) return false;
+
+    const { startBlock, endBlock } = value;
+
+    // Only handle events in cells
+    return (startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell) 
+}
+
+export default isSelectionOutOfTable;

--- a/lib/utils/isSelectionOutOfTable.js
+++ b/lib/utils/isSelectionOutOfTable.js
@@ -12,7 +12,7 @@ function isSelectionOutOfTable(opts: Options, value: Value): boolean {
     const { startBlock, endBlock } = value;
 
     // Only handle events in cells
-    return (startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell) 
+    return startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell;
 }
 
 export default isSelectionOutOfTable;

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -159,7 +159,7 @@ function rowsWithinTable(opts: Options): Rule {
                     {
                         type: opts.typeTable,
                         data: {
-                            align: createAlign(row.nodes.size)
+                            presetAlign: createAlign(row.nodes.size)
                         }
                     },
                     { normalize: false }
@@ -299,11 +299,13 @@ function tableContainAlignData(opts: Options): Rule {
         },
 
         validate(table) {
-            const align = table.data.get('align', []);
+            const presetAlign = table.data.get('presetAlign', []);
             const row = table.nodes.first();
             const columns = row.nodes.size;
 
-            return align.length == columns ? null : { align, columns };
+            return presetAlign.length == columns
+                ? null
+                : { presetAlign, columns };
         },
 
         /**
@@ -312,12 +314,15 @@ function tableContainAlignData(opts: Options): Rule {
         normalize(
             change,
             node,
-            { align, columns }: { align: string[], columns: number }
+            { presetAlign, columns }: { presetAlign: string[], columns: number }
         ) {
             return change.setNodeByKey(
                 node.key,
                 {
-                    data: node.data.set('align', createAlign(columns, align))
+                    data: node.data.set(
+                        'presetAlign',
+                        createAlign(columns, presetAlign)
+                    )
                 },
                 { normalize: false }
             );

--- a/tests/backspace-clear-cells/expected.yaml
+++ b/tests/backspace-clear-cells/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/insert-column-at/expected.yaml
+++ b/tests/insert-column-at/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - left
           - center
@@ -19,6 +19,8 @@ document:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -40,6 +42,8 @@ document:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -61,6 +65,8 @@ document:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column-at/input.yaml
+++ b/tests/insert-column-at/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - center
       nodes:

--- a/tests/insert-column-preserve-data/expected.yaml
+++ b/tests/insert-column-preserve-data/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - left
           - center
@@ -20,6 +20,8 @@ document:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -41,6 +43,8 @@ document:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -62,6 +66,8 @@ document:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column-preserve-data/input.yaml
+++ b/tests/insert-column-preserve-data/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - center
         custom: value

--- a/tests/insert-column/expected.yaml
+++ b/tests/insert-column/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left
@@ -25,6 +25,8 @@ document:
                     - text: "Col 1, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -46,6 +48,8 @@ document:
                     - text: "Col 1, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -67,6 +71,8 @@ document:
                     - text: "Col 1, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column/input.yaml
+++ b/tests/insert-column/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
       nodes:

--- a/tests/insert-row/expected.yaml
+++ b/tests/insert-row/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left
@@ -55,18 +55,24 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-row/input.yaml
+++ b/tests/insert-row/input.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/insert-table/expected.yaml
+++ b/tests/insert-table/expected.yaml
@@ -9,7 +9,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
       nodes:
@@ -18,12 +18,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -33,12 +37,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/mod-enter-exit-table/expected.yaml
+++ b/tests/mod-enter-exit-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/on-shift-tab-first-cell/expected.yaml
+++ b/tests/on-shift-tab-first-cell/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left      

--- a/tests/on-tab-last-cell/expected.yaml
+++ b/tests/on-tab-last-cell/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-column-first/expected.yaml
+++ b/tests/remove-column-first/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - right
           - center
       nodes:

--- a/tests/remove-column-first/input.yaml
+++ b/tests/remove-column-first/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-column-last-one/expected.yaml
+++ b/tests/remove-column-last-one/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/remove-column-last-one/input.yaml
+++ b/tests/remove-column-last-one/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/remove-column-preserve-data/expected.yaml
+++ b/tests/remove-column-preserve-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
           - left
           - center
       nodes:

--- a/tests/remove-column-preserve-data/input.yaml
+++ b/tests/remove-column-preserve-data/input.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-column/expected.yaml
+++ b/tests/remove-column/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - center
       nodes:

--- a/tests/remove-column/input.yaml
+++ b/tests/remove-column/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-row-first/expected.yaml
+++ b/tests/remove-row-first/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-row-last-one/expected.yaml
+++ b/tests/remove-row-last-one/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-row/expected.yaml
+++ b/tests/remove-row/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/schema-no-blocks-within-cells/expected.yaml
+++ b/tests/schema-no-blocks-within-cells/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-cells/input.yaml
+++ b/tests/schema-no-blocks-within-cells/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-rows/expected.yaml
+++ b/tests/schema-no-blocks-within-rows/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-rows/input.yaml
+++ b/tests/schema-no-blocks-within-rows/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-table/expected.yaml
+++ b/tests/schema-no-blocks-within-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-table/input.yaml
+++ b/tests/schema-no-blocks-within-table/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-orphan-cells/expected.yaml
+++ b/tests/schema-orphan-cells/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -19,7 +19,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-rows-cells-within-tables/expected.yaml
+++ b/tests/schema-rows-cells-within-tables/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -18,7 +18,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-rows-require-same-columns-counts/expected.yaml
+++ b/tests/schema-rows-require-same-columns-counts/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-rows-require-same-columns-counts/input.yaml
+++ b/tests/schema-rows-require-same-columns-counts/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-standard-table/expected.yaml
+++ b/tests/schema-standard-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/schema-tables-contain-rows-empty/expected.yaml
+++ b/tests/schema-tables-contain-rows-empty/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-tables-contain-rows-invalid/expected.yaml
+++ b/tests/schema-tables-contain-rows-invalid/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         # Row 1

--- a/tests/schema-tables-contain-rows-mixed/expected.yaml
+++ b/tests/schema-tables-contain-rows-mixed/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -20,7 +20,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         # Row 1

--- a/tests/set-column-align-center-and-right/expected.yaml
+++ b/tests/set-column-align-center-and-right/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - center
             - right
       nodes:
@@ -12,12 +12,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -27,12 +31,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -42,12 +50,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-center-and-right/input.yaml
+++ b/tests/set-column-align-center-and-right/input.yaml
@@ -2,6 +2,10 @@ document:
   nodes:
     - kind: block
       type: table
+      data:
+        presetAlign: 
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/set-column-align-left/expected.yaml
+++ b/tests/set-column-align-left/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - left
             - left
       nodes:
@@ -13,12 +13,16 @@ document:
             # at argument is set to 1, so this column gets left aligned
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -28,12 +32,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -43,12 +51,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-left/input.yaml
+++ b/tests/set-column-align-left/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - center
             - left
       nodes:

--- a/tests/set-column-align-preserve-data/expected.yaml
+++ b/tests/set-column-align-preserve-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
             - center
             - right
       nodes:
@@ -13,12 +13,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -28,12 +32,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -43,12 +51,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-preserve-data/input.yaml
+++ b/tests/set-column-align-preserve-data/input.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
           custom: value
-          align:
+          presetAlign:
               - left
               - left
       nodes:

--- a/tests/undo-insert-row/expected.yaml
+++ b/tests/undo-insert-row/expected.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/undo-insert-row/input.yaml
+++ b/tests/undo-insert-row/input.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row


### PR DESCRIPTION
Sorry, for my inept of using github, I merged two PR together...

Two features are added in this PR:

###   Add `isSelectionOutOfTable` method:
Operations like `insertTable` causes unwise behavior when `{startBlock, endBlock}` have one inside a table and the other outside tables.  I think it could be better if a function `isSelectionOutOfTable` is provided.

### Better Alignment
The alignment is working working in the `example` and `demo`, which is due to `cell.data.align` is not set.  Here I add some codes to ensure the cell.data is updated according to `table.data`.

I also change the `table.data.align` to `table.data.presetAlign`, because:
1. There could be a upcomming plugin about "text-align" for blocks use "data.align" to center the table
2. To distinguish the difference between the `Array<align as string>` in the table.data and `align as string` in the cell.data.  I think it may be better to distinguish the two different align by the variable names.

Cheers,
