### PR TITLE
GetFragmentAtRange

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,8 @@
 {
     "presets": [
+        "flow",
         "es2015",
         "stage-0",
         "react"
-    ],
-    "plugins": [
-        "transform-flow-strip-types"
     ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,3 @@
 [options]
 emoji=true
 esproposal.decorators=ignore
-unsafe.enable_getters_and_setters=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+## [0.13.1] - 2017-12-05
+
+- Improve `isSelectionInTable` to check for both end of the selection to be in the same table.
+
 ## [0.13.0] - 2017-11-22
 
 **BREAKING**

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Return true if selection starts and ends both outside any table.  (Notice: it is
 
 Returns the detailed position in the current table. Throws if not in a table.
 
+#### `utils.getFragmentAtRange`
+`plugin.utils.getFragmentAtRange(node: Node, range: Range) => Document` 
+
+customized function for copy at selection
+
 #### `changes.insertTable`
 
 `plugin.changes.insertTable(change: Change, columns: ?number, rows: ?number) => Change`
@@ -119,6 +124,22 @@ defaults to center, `at` is optional and defaults to current cursor position.
 > `table.node.data.get('align')` should be an array of aligns string, corresponding to
 each column.
 
+### Rules
+
+Parser-Combinator rules for customize copy and paste
+
+#### `rules.getFragmentAtRange`
+
+```
+pligin.rules.getFragmentAtRange: Array< (
+    getFragmentAtRangeAsParser : ((Node, Range) => Document,
+    node: Node, 
+    range: Range, 
+    next: () => Document) => Document
+    )>
+```
+See details `bindRules(...args)` in `lib/rules/getFragmentAtRange/index.js`
+
 ### TablePosition
 
 An instance of `TablePosition` represents a position within a table (row and column).
@@ -163,3 +184,6 @@ True if on first column
 #### `position.isLastColumn() => boolean`
 
 True if on last column
+
+
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ const plugins = [
 
 Return true if selection is inside a table cell.
 
+#### `utils.isSelectionOutOfTable`
+
+`plugin.utils.isSelectionOutOfTable(value: Slate.Value) => boolean`
+
+Return true if selection starts and ends both outside any table.  (Notice: it is NOT the opposite value of `isSelectionInTable`)
+
 #### `utils.getPosition`
 
 `plugin.utils.getPosition(value: Slate.Value) => TablePosition`

--- a/example/main.js
+++ b/example/main.js
@@ -135,13 +135,13 @@ class Example extends React.Component<*, *> {
 
     render() {
         const { value } = this.state;
-        const isTable = tablePlugin.utils.isSelectionInTable(value);
+        const isInTable = tablePlugin.utils.isSelectionInTable(value);
+        const isOutTable = tablePlugin.utils.isSelectionOutOfTable(value);
 
         return (
             <div>
-                {isTable
-                    ? this.renderTableToolbar()
-                    : this.renderNormalToolbar()}
+                {isInTable ? this.renderTableToolbar(): null}
+                {isOutTable? this.renderNormalToolbar(): null}
                 <Editor
                     placeholder={'Enter some text...'}
                     renderNode={renderNode}

--- a/example/main.js
+++ b/example/main.js
@@ -53,6 +53,8 @@ function renderNode(props: NodeProps): React.Node {
 }
 
 class Example extends React.Component<*, *> {
+    submitChange: Function;
+    editorREF: Editor;
     state = {
         value: INITIAL_VALUE
     };
@@ -86,7 +88,7 @@ class Example extends React.Component<*, *> {
             </div>
         );
     }
-    setEditorComponent = ref => {
+    setEditorComponent = (ref: Editor) => {
         this.editorREF = ref;
         this.submitChange = ref.change;
     };

--- a/example/main.js
+++ b/example/main.js
@@ -61,12 +61,12 @@ class Example extends React.Component<*, *> {
 
     renderTableToolbar() {
         return (
-            <div onMouseLeave={this.onMouseLeave}>
-                <button onClick={this.onInsertColumn}>Insert Column</button>
-                <button onClick={this.onInsertRow}>Insert Row</button>
-                <button onClick={this.onRemoveColumn}>Remove Column</button>
-                <button onClick={this.onRemoveRow}>Remove Row</button>
-                <button onClick={this.onRemoveTable}>Remove Table</button>
+            <div>
+                <button onMouseDown={this.onInsertColumn}>Insert Column</button>
+                <button onMouseDown={this.onInsertRow}>Insert Row</button>
+                <button onMouseDown={this.onRemoveColumn}>Remove Column</button>
+                <button onMouseDown={this.onRemoveRow}>Remove Row</button>
+                <button onMouseDown={this.onRemoveTable}>Remove Table</button>
                 <br />
                 <button onClick={e => this.onSetAlign(e, 'left')}>
                     Set align left
@@ -97,15 +97,6 @@ class Example extends React.Component<*, *> {
         this.setState({
             value
         });
-    };
-    onMouseLeave = event => {
-        event.preventDefault();
-        this.submitChange(change =>
-            change
-                .setOperationFlag('save', false)
-                .focus()
-                .setOperationFlag('save', true)
-        );
     };
 
     onInsertTable = event => {

--- a/example/main.js
+++ b/example/main.js
@@ -68,13 +68,13 @@ class Example extends React.Component<*, *> {
                 <button onMouseDown={this.onRemoveRow}>Remove Row</button>
                 <button onMouseDown={this.onRemoveTable}>Remove Table</button>
                 <br />
-                <button onClick={e => this.onSetAlign(e, 'left')}>
+                <button onMouseDown={e => this.onSetAlign(e, 'left')}>
                     Set align left
                 </button>
-                <button onClick={e => this.onSetAlign(e, 'center')}>
+                <button onMouseDown={e => this.onSetAlign(e, 'center')}>
                     Set align center
                 </button>
-                <button onClick={e => this.onSetAlign(e, 'right')}>
+                <button onMouseDown={e => this.onSetAlign(e, 'right')}>
                     Set align right
                 </button>
             </div>

--- a/lib/changes/insertColumn.js
+++ b/lib/changes/insertColumn.js
@@ -30,17 +30,18 @@ function insertColumn(
 
     // Insert the new cell
     table.nodes.forEach(row => {
-        const newCell = createCell(opts.typeCell);
+        let newCell = createCell(opts.typeCell);
+        newCell = newCell.setIn(['data', 'textAlign'], ALIGN.DEFAULT);
         change.insertNodeByKey(row.key, at, newCell, { normalize: false });
     });
 
     // Update alignment
-    let align = table.data.get('align');
-    align = List(align)
+    let presetAlign = table.data.get('presetAlign');
+    presetAlign = List(presetAlign)
         .insert(at, columnAlign)
         .toArray();
     change.setNodeByKey(table.key, {
-        data: table.data.set('align', align)
+        data: table.data.set('presetAlign', presetAlign)
     });
 
     // Update the selection (not doing can break the undo)

--- a/lib/changes/insertRow.js
+++ b/lib/changes/insertRow.js
@@ -3,6 +3,7 @@ import { type Change } from 'slate';
 
 import { TablePosition, createRow } from '../utils';
 import type Options from '../options';
+import getAdjustedRow from '../helpers/getAdjustedRow';
 
 /**
  * Insert a new row in current table
@@ -21,7 +22,9 @@ function insertRow(
 
     // Create a new row with the right count of cells
     const firstRow = table.nodes.get(0);
-    const newRow = createRow(opts, firstRow.nodes.size, textGetter);
+    const presetAlign = table.data.get('presetAlign');
+    let newRow = createRow(opts, firstRow.nodes.size, textGetter);
+    newRow = getAdjustedRow(newRow, presetAlign);
 
     if (typeof at === 'undefined') {
         at = pos.getRowIndex() + 1;

--- a/lib/changes/removeColumn.js
+++ b/lib/changes/removeColumn.js
@@ -29,12 +29,12 @@ function removeColumn(opts: Options, change: Change, at: number): Change {
         });
 
         // Update alignment
-        let align = table.data.get('align');
-        align = List(align)
+        let presetAlign = table.data.get('presetAlign');
+        presetAlign = List(presetAlign)
             .delete(at)
             .toArray();
         change.setNodeByKey(table.key, {
-            data: table.data.set('align', align)
+            data: table.data.set('presetAlign', presetAlign)
         });
     } else {
         // If last column, clear text in cells instead

--- a/lib/changes/setColumnAlign.js
+++ b/lib/changes/setColumnAlign.js
@@ -4,6 +4,7 @@ import { type Change } from 'slate';
 import { TablePosition, createAlign } from '../utils';
 import ALIGN from '../ALIGN';
 import type Options from '../options';
+import setTableAlign from './setTableAlign';
 
 /**
  * Sets column alignment for a given column
@@ -11,7 +12,7 @@ import type Options from '../options';
 function setColumnAlign(
     opts: Options,
     change: Change,
-    align: string = ALIGN.DEFAULT,
+    cellAlign: string = ALIGN.DEFAULT,
     at: number
 ): Change {
     const { value } = change;
@@ -25,14 +26,9 @@ function setColumnAlign(
         at = pos.getColumnIndex();
     }
 
-    const newAlign = createAlign(pos.getWidth(), table.data.get('align'));
-    newAlign[at] = align;
-
-    change.setNodeByKey(table.key, {
-        data: table.data.set('align', newAlign)
-    });
-
-    return change;
+    const newAlign = createAlign(pos.getWidth(), table.data.get('presetAlign'));
+    newAlign[at] = cellAlign;
+    return setTableAlign(opts, change, table, newAlign);
 }
 
 export default setColumnAlign;

--- a/lib/changes/setTableAlign.js
+++ b/lib/changes/setTableAlign.js
@@ -1,0 +1,35 @@
+// @flow
+import { type Change, type Block } from 'slate';
+import type Options from '../options';
+import getAdjustedRow from '../helpers/getAdjustedRow';
+
+/**
+ * Sets column alignment for a given column
+ */
+function setTableAlign(
+    opts: Options,
+    change: Change,
+    table: Block,
+    presetAlign: Array<string>
+): Change {
+    const nextTable = table
+        .set('nodes', table.nodes.map(row => getAdjustedRow(row, presetAlign)))
+        .setIn(['data', 'presetAlign'], presetAlign);
+
+    // To restore selection, the following code function like change.replaceNodeByKey(table.key, nextTable).focus();
+    change.setNodeByKey(table.key, { data: nextTable.data });
+    table.nodes.forEach((row, rowIndex) => {
+        row.nodes.forEach((cell, cellIndex) => {
+            const nextCell = nextTable.nodes.get(rowIndex).nodes.get(cellIndex);
+            if (nextCell === cell) {
+                return cellIndex;
+            }
+            change.setNodeByKey(cell.key, { data: nextCell.data });
+            return cellIndex;
+        });
+        return rowIndex;
+    });
+
+    return change;
+}
+export default setTableAlign;

--- a/lib/core.js
+++ b/lib/core.js
@@ -16,7 +16,7 @@ import {
     getPosition
 } from './utils';
 import { schema, validateNode } from './validation';
-
+import createRulePatch from './rules/index';
 import ALIGN from './ALIGN';
 import Options, { type OptionsFormat } from './options';
 
@@ -29,8 +29,19 @@ import Options, { type OptionsFormat } from './options';
  * are only manipulating `Slate.Values` without rendering them.
  * That way you do not depend on `slate-react`.
  */
-function core(optionsParam: Options | OptionsFormat): Object {
+
+type typeCore = {
+    schema: Object,
+    validateNode: Function,
+    utils: Object,
+    changes: Object,
+    rules: Object
+};
+
+function core(optionsParam: Options | OptionsFormat): typeCore {
     const opts = new Options(optionsParam);
+
+    const rulesPatch = createRulePatch(opts);
 
     return {
         schema: schema(opts),
@@ -39,9 +50,10 @@ function core(optionsParam: Options | OptionsFormat): Object {
         utils: {
             isSelectionInTable: isSelectionInTable.bind(null, opts),
             isSelectionOutOfTable: isSelectionOutOfTable.bind(null, opts),
-            getPosition: getPosition.bind(null, opts)
+            getPosition: getPosition.bind(null, opts),
+            getFragmentAtRange: rulesPatch.utils.getFragmentAtRange
         },
-
+        rules: rulesPatch.rules,
         changes: {
             insertTable: insertTable.bind(null, opts),
             insertRow: bindAndScopeChange(opts, insertRow),

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,7 +10,7 @@ import {
     moveSelectionBy,
     setColumnAlign
 } from './changes';
-import { isSelectionInTable, getPosition } from './utils';
+import { isSelectionInTable, isSelectionOutOfTable, getPosition } from './utils';
 import { schema, validateNode } from './validation';
 
 import ALIGN from './ALIGN';
@@ -34,6 +34,7 @@ function core(optionsParam: Options | OptionsFormat): Object {
 
         utils: {
             isSelectionInTable: isSelectionInTable.bind(null, opts),
+            isSelectionOutOfTable: isSelectionOutOfTable.bind(null, opts),
             getPosition: getPosition.bind(null, opts)
         },
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,7 +10,11 @@ import {
     moveSelectionBy,
     setColumnAlign
 } from './changes';
-import { isSelectionInTable, isSelectionOutOfTable, getPosition } from './utils';
+import {
+    isSelectionInTable,
+    isSelectionOutOfTable,
+    getPosition
+} from './utils';
 import { schema, validateNode } from './validation';
 
 import ALIGN from './ALIGN';

--- a/lib/handlers/onKeyDown.js
+++ b/lib/handlers/onKeyDown.js
@@ -15,7 +15,7 @@ const KEY_ENTER = 'Enter';
 const KEY_TAB = 'Tab';
 const KEY_BACKSPACE = 'Backspace';
 const KEY_DOWN = 'ArrowDown';
-const KEY_UP = 'ArrowUp1';
+const KEY_UP = 'ArrowUp';
 
 /**
  * User is pressing a key in the editor

--- a/lib/handlers/onUpDown.js
+++ b/lib/handlers/onUpDown.js
@@ -11,7 +11,7 @@ function onUpDown(
     editor: *,
     opts: Options
 ): void | Change {
-    const direction = event.key === 'UpArrow' ? -1 : +1;
+    const direction = event.key === 'ArrowUp' ? -1 : +1;
     const pos = TablePosition.create(change.value, change.value.startBlock);
 
     if (
@@ -23,7 +23,7 @@ function onUpDown(
     }
     event.preventDefault();
 
-    moveSelectionBy(opts, change, 0, event.key === 'UpArrow' ? -1 : +1);
+    moveSelectionBy(opts, change, 0, event.key === 'ArrowUp' ? -1 : +1);
 
     return change;
 }

--- a/lib/helpers/getAdjustedRow.js
+++ b/lib/helpers/getAdjustedRow.js
@@ -1,0 +1,21 @@
+// @flow
+import { type Block } from 'slate';
+
+function getAdjustedRow(row: Block, presetAlign?: Array<string>) {
+    if (!presetAlign) {
+        return row;
+    }
+    const nodes = row.nodes;
+    const nextRow = row.set(
+        'nodes',
+        nodes.map((cell, index) => {
+            if (cell.data.get('textAlign') === presetAlign[index]) {
+                return cell;
+            }
+            return cell.setIn(['data', 'textAlign'], presetAlign[index]);
+        })
+    );
+    return nextRow;
+}
+
+export default getAdjustedRow;

--- a/lib/helpers/getAdjustedRow.js
+++ b/lib/helpers/getAdjustedRow.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Block } from 'slate';
 
-function getAdjustedRow(row: Block, presetAlign?: Array<string>) {
+function getAdjustedRow(row: Block, presetAlign: Array<string>) {
     if (!presetAlign) {
         return row;
     }

--- a/lib/rules/getFragmentAtRange/edgeInTable.js
+++ b/lib/rules/getFragmentAtRange/edgeInTable.js
@@ -1,0 +1,59 @@
+// @flow
+import { type Node, Range, type Document } from 'slate';
+import type Options from '../../options';
+
+function edgeInTable(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { startKey, endKey, startOffset, endOffset } = range;
+
+    const startBlock = node.getClosestBlock(startKey);
+    const endBlock = node.getClosestBlock(endKey);
+
+    if (startBlock.type === opts.typeCell) {
+        const table = node.getAncestors(startBlock.key).get(-2);
+        const beforeFragment = rootGetFragment(
+            node,
+            Range.create()
+                .moveAnchorTo(startKey, startOffset)
+                .moveFocusToEndOf(table)
+        );
+        const contentFragment = rootGetFragment(
+            node,
+            Range.create()
+                .moveAnchorToEndOf(table)
+                .moveFocusTo(endKey, endOffset)
+        );
+        return beforeFragment.set(
+            'nodes',
+            beforeFragment.nodes.concat(contentFragment.nodes)
+        );
+    }
+
+    if (endBlock.type === opts.typeCell) {
+        const table = node.getAncestors(endBlock.key).get(-2);
+        const afterFragment = rootGetFragment(
+            node,
+            Range.create()
+                .moveAnchorToStartOf(table)
+                .moveFocusTo(endKey, endOffset)
+        );
+        const contentFragment = rootGetFragment(
+            node,
+            Range.create()
+                .moveAnchorTo(startKey, startOffset)
+                .moveFocusToStartOf(table)
+        );
+        return contentFragment.set(
+            'nodes',
+            contentFragment.nodes.concat(afterFragment.nodes)
+        );
+    }
+    return next();
+}
+
+export default edgeInTable;

--- a/lib/rules/getFragmentAtRange/endAtStartOfTable.js
+++ b/lib/rules/getFragmentAtRange/endAtStartOfTable.js
@@ -1,0 +1,36 @@
+// @flow
+import { type Node, Range, Document } from 'slate';
+import type Options from '../../options';
+
+function endAtStartOfTable(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { endKey, endOffset } = range;
+
+    const endBlock = node.getClosestBlock(endKey);
+    if (!endBlock || endBlock.type !== opts.typeCell) {
+        return next();
+    }
+    const table = node.getAncestors(endBlock.key).get(-2);
+    if (table.getFirstText().key !== endKey || endOffset !== 0) {
+        return next();
+    }
+
+    const prevText = node.getPreviousText(endKey);
+
+    if (!prevText) {
+        return node.getFragmentAtRange(range);
+    }
+
+    const prevRange = Range.create()
+        .moveAnchorTo(range.startKey, range.startOffset)
+        .moveFocusToEndOf(prevText);
+
+    return rootGetFragment(node, prevRange);
+}
+
+export default endAtStartOfTable;

--- a/lib/rules/getFragmentAtRange/ifCollapsed.js
+++ b/lib/rules/getFragmentAtRange/ifCollapsed.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { type Node, type Range, type Document } from 'slate';
+import type Options from '../../options';
+
+function ifCollapsed(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    if (range.isCollapsed) {
+        return node.getFragmentAtRange(range);
+    }
+    return next();
+}
+export default ifCollapsed;

--- a/lib/rules/getFragmentAtRange/inSameCell.js
+++ b/lib/rules/getFragmentAtRange/inSameCell.js
@@ -1,0 +1,23 @@
+// @flow
+import { type Node, type Range, type Document } from 'slate';
+import type Options from '../../options';
+import isSameCell from '../utils/isSameCell';
+
+function inSameCell(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { startKey, endKey } = range;
+    if (startKey === endKey) {
+        return node.getFragmentAtRange(range);
+    }
+
+    if (isSameCell(opts, node, startKey, endKey)) {
+        return node.getFragmentAtRange(range);
+    }
+    return next();
+}
+export default inSameCell;

--- a/lib/rules/getFragmentAtRange/inSameRow.js
+++ b/lib/rules/getFragmentAtRange/inSameRow.js
@@ -1,0 +1,20 @@
+// @flow
+import { type Node, type Range, type Document } from 'slate';
+import type Options from '../../options';
+import isSameRow from '../utils/isSameRow';
+
+function inSameRow(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { startKey, endKey } = range;
+    if (isSameRow(opts, node, startKey, endKey)) {
+        return node.getFragmentAtRange(range);
+    }
+    return next();
+}
+
+export default inSameRow;

--- a/lib/rules/getFragmentAtRange/inSameTable.js
+++ b/lib/rules/getFragmentAtRange/inSameTable.js
@@ -1,0 +1,41 @@
+// @flow
+import { type Node, Range, Document } from 'slate';
+import type Options from '../../options';
+// import getNextRange from '../utils/getNextRange';
+import isSameTable from '../utils/isSameTable';
+
+function inSameTable(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { startKey, endKey } = range;
+    if (!isSameTable(opts, node, startKey, endKey)) {
+        return next();
+    }
+    const startCell = node.getClosestBlock(startKey);
+    const endCell = node.getClosestBlock(endKey);
+    const firstCell = node.getParent(startCell.key).nodes.first();
+    const lastCell = node.getParent(endCell.key).nodes.last();
+    if (firstCell !== startCell) {
+        const { endOffset } = range;
+        const startFixedRange = Range.create()
+            .moveAnchorToStartOf(firstCell)
+            .moveFocusTo(endKey, endOffset);
+        return rootGetFragment(node, startFixedRange);
+    }
+    if (lastCell !== endCell) {
+        const { startOffset } = range;
+        return rootGetFragment(
+            node,
+            Range.create()
+                .moveAnchorTo(startKey, startOffset)
+                .moveFocusToEndOf(lastCell)
+        );
+    }
+    return node.getFragmentAtRange(range);
+}
+
+export default inSameTable;

--- a/lib/rules/getFragmentAtRange/index.js
+++ b/lib/rules/getFragmentAtRange/index.js
@@ -1,0 +1,90 @@
+// @flow
+import { type Node, type Range, type Document } from 'slate';
+import ifCollapsed from './ifCollapsed';
+import inSameCell from './inSameCell';
+import inSameRow from './inSameRow';
+import inSameTable from './inSameTable';
+import startAtEndOfTable from './startAtEndOfTable';
+import endAtStartOfTable from './endAtStartOfTable';
+import edgeInTable from './edgeInTable';
+
+import type Options from '../../options';
+
+type typeRules = Array<
+    (
+        Options,
+        (Node, Range) => Document,
+        Node,
+        Range,
+        () => Document
+    ) => Document
+>;
+
+const getFragmentRules: typeRules = [
+    ifCollapsed,
+    inSameCell,
+    inSameRow,
+    inSameTable,
+    startAtEndOfTable,
+    endAtStartOfTable,
+    edgeInTable
+];
+
+function bindRules(
+    rules: typeRules,
+    index: number,
+    opts: Options,
+    node: Node,
+    range: Range
+): Document {
+    if (index === rules.length) {
+        return node.getFragmentAtRange(range);
+    }
+    const rule = rules[index];
+    const next = () => bindRules(rules, index + 1, opts, node, range);
+    const rootGetFragment = (n: Node, r: Range) =>
+        bindRules(getFragmentRules, 0, opts, n, r);
+    return rule(opts, rootGetFragment, node, range, next);
+}
+
+type typeRule = (
+    (Node, Range) => Document,
+    Node,
+    Range,
+    () => Document
+) => Document;
+function convertSingleRule(
+    opts: Options,
+    optsRule: (
+        Options,
+        (Node, Range) => Document,
+        Node,
+        Range,
+        () => Document
+    ) => Document
+): typeRule {
+    return (node, rootGet, range, next) =>
+        optsRule(opts, rootGet, node, range, next);
+}
+
+type typePatch = {
+    rules: {
+        getFragmentAtRange: Array<typeRule>
+    },
+    utils: { getFragmentAtRange: (Node, Range) => Document }
+};
+function makePatch(opts: Options): typePatch {
+    return {
+        rules: {
+            getFragmentAtRange: getFragmentRules.map(rule =>
+                convertSingleRule(opts, rule)
+            )
+        },
+        utils: {
+            getFragmentAtRange: (node: Node, range: Range) =>
+                bindRules(getFragmentRules, 0, opts, node, range)
+        }
+    };
+}
+
+export default makePatch;

--- a/lib/rules/getFragmentAtRange/startAtEndOfTable.js
+++ b/lib/rules/getFragmentAtRange/startAtEndOfTable.js
@@ -1,0 +1,36 @@
+// @flow
+import { type Node, Range, Document } from 'slate';
+import type Options from '../../options';
+
+function startAtEndOfTable(
+    opts: Options,
+    rootGetFragment: (Node, Range) => Document,
+    node: Node,
+    range: Range,
+    next: () => Document
+): Document {
+    const { startKey, startOffset } = range;
+
+    const startBlock = node.getClosestBlock(startKey);
+    if (!startBlock || startBlock.type !== opts.typeCell) {
+        return next();
+    }
+
+    const table = node.getAncestors(startBlock.key).get(-2);
+    const startText = table.getLastText();
+    if (startText.key !== startKey || startText.text.length !== startOffset) {
+        return next();
+    }
+
+    const nextText = node.getNextText(startKey);
+    if (!nextText) {
+        return node.getFragmentAtRange(range);
+    }
+    const nextRange = Range.create()
+        .moveAnchorToStartOf(nextText)
+        .moveFocusTo(range.endKey, range.endOffset);
+
+    return rootGetFragment(node, nextRange);
+}
+
+export default startAtEndOfTable;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,0 +1,25 @@
+// @flow
+import { type Node, type Range, type Document } from 'slate';
+import makeGetFragmentAtRange from './getFragmentAtRange/index';
+import type Options from '../options';
+
+type typePatch = {
+    utils: {
+        getFragmentAtRange: (Node, Range) => Document
+    },
+    rules: {
+        getFragmentAtRange: Array<
+            ((Node, Range) => Document, Node, Range, () => Document) => Document
+        >
+    }
+};
+
+function createPatch(opts: Options): typePatch {
+    const patchGetFragmentAtRange = makeGetFragmentAtRange(opts);
+    return {
+        utils: { ...patchGetFragmentAtRange.utils },
+        rules: { ...patchGetFragmentAtRange.rules }
+    };
+}
+
+export default createPatch;

--- a/lib/rules/utils/getNextRange.js
+++ b/lib/rules/utils/getNextRange.js
@@ -1,0 +1,33 @@
+// @flow
+import { type Node, Range } from 'slate';
+
+function getNextRange(
+    node: Node,
+    range: Range,
+    shouldFix: { shouldFixStart: boolean, shouldFixEnd: boolean }
+): Range {
+    const { shouldFixStart, shouldFixEnd } = shouldFix;
+
+    let { startKey, startOffset, endKey, endOffset } = range;
+    if (shouldFixStart) {
+        const cell = node.getClosestBlock(startKey);
+        const row = node.getParent(cell);
+        const startText = row.getFirstText();
+        startKey = startText.key;
+        startOffset = 0;
+    }
+
+    if (shouldFixEnd) {
+        const cell = node.getClosestBlock(endKey);
+        const row = node.getParent(cell);
+        const endText = row.findLastText();
+        endKey = endText.key;
+        endOffset = endText.text.length;
+    }
+
+    return Range.create()
+        .moveAnchorTo(startKey, startOffset)
+        .moveFocusTo(endKey, endOffset);
+}
+
+export default getNextRange;

--- a/lib/rules/utils/isSameCell.js
+++ b/lib/rules/utils/isSameCell.js
@@ -1,0 +1,20 @@
+// @flow
+import { type Node } from 'slate';
+import type Options from '../../options';
+
+function isSameCell(
+    opts: Options,
+    document: Node,
+    startKey: string,
+    endKey: string
+): boolean {
+    const startBlock = document.getClosestBlock(startKey);
+    const endBlock = document.getClosestBlock(endKey);
+    return !!(
+        startBlock &&
+        startBlock === endBlock &&
+        startBlock.type === opts.typeCell &&
+        endBlock.type === opts.typeCell
+    );
+}
+export default isSameCell;

--- a/lib/rules/utils/isSameRow.js
+++ b/lib/rules/utils/isSameRow.js
@@ -1,0 +1,29 @@
+// @flow
+import { type Node } from 'slate';
+import type Options from '../../options';
+
+function isSameRow(
+    opts: Options,
+    document: Node,
+    startKey: string,
+    endKey: string
+): boolean {
+    const startBlock = document.getClosestBlock(startKey);
+    const endBlock = document.getClosestBlock(endKey);
+    if (
+        !startBlock ||
+        !endBlock ||
+        startBlock.type !== opts.typeCell ||
+        endBlock.type !== opts.typeCell
+    ) {
+        return false;
+    }
+    const startRow = document.getParent(startBlock.key);
+
+    return !!(
+        startRow &&
+        startRow.type === opts.typeRow &&
+        startRow.nodes.indexOf(endBlock) !== -1
+    );
+}
+export default isSameRow;

--- a/lib/rules/utils/isSameTable.js
+++ b/lib/rules/utils/isSameTable.js
@@ -1,0 +1,29 @@
+// @flow
+import { type Node } from 'slate';
+import type Options from '../../options';
+
+function isSameTable(
+    opts: Options,
+    document: Node,
+    startKey: string,
+    endKey: string
+): boolean {
+    const startBlock = document.getClosestBlock(startKey);
+    const endBlock = document.getClosestBlock(endKey);
+    if (
+        !startBlock ||
+        !endBlock ||
+        startBlock.type !== opts.typeCell ||
+        endBlock.type !== opts.typeCell
+    ) {
+        return false;
+    }
+    const startTable = document.getAncestors(startBlock.key).get(-2);
+    const endTable = document.getAncestors(endBlock.key).get(-2);
+    return !!(
+        startTable === endTable &&
+        startTable &&
+        startTable.type === opts.typeTable
+    );
+}
+export default isSameTable;

--- a/lib/rules/utils/removeAllTextsInCell.js
+++ b/lib/rules/utils/removeAllTextsInCell.js
@@ -1,0 +1,8 @@
+// @flow
+import { type Change, Node, Range } from 'slate';
+
+function removeAllTextsInCell(change: Change, node: Node): Change {
+    const cellRange = Range.create().moveToRangeOf(node);
+    return change.deleteAtRange(cellRange);
+}
+export default removeAllTextsInCell;

--- a/lib/rules/utils/removeTextsFromEnd.js
+++ b/lib/rules/utils/removeTextsFromEnd.js
@@ -1,0 +1,18 @@
+// @flow
+import { type Change, Range } from 'slate';
+
+function removeTextsFromEnd(change: Change, range: Range): Change {
+    const { endKey, endOffset } = range;
+    const { document } = change.value;
+    const block = document.getClosestBlock(endKey);
+
+    if (!block) {
+        return change;
+    }
+
+    const cellRange = Range.create()
+        .moveFocusTo(endKey, endOffset)
+        .moveAnchorToStartOf(block);
+    return change.deleteAtRange(cellRange);
+}
+export default removeTextsFromEnd;

--- a/lib/rules/utils/removeTextsFromStart.js
+++ b/lib/rules/utils/removeTextsFromStart.js
@@ -1,0 +1,15 @@
+// @flow
+import { type Change, Range } from 'slate';
+
+function removeTextsFromStart(change: Change, range: Range): Change {
+    const { startKey, startOffset } = range;
+    const { document } = change.value;
+    const block = document.getClosestBlock(startKey);
+    if (!block) return change;
+
+    const cellRange = Range.create()
+        .moveAnchorTo(startKey, startOffset)
+        .moveFocusToEndOf(block);
+    return change.deleteAtRange(cellRange);
+}
+export default removeTextsFromStart;

--- a/lib/utils/createCell.js
+++ b/lib/utils/createCell.js
@@ -9,7 +9,7 @@ function createCell(type: string, text?: string = ''): Block {
         type,
         nodes: [
             Text.fromJSON({
-                kind: 'text',
+                object: 'text',
                 text
             })
         ]

--- a/lib/utils/createTable.js
+++ b/lib/utils/createTable.js
@@ -6,6 +6,7 @@ import type Options from '../options';
 
 import createRow from './createRow';
 import createAlign from './createAlign';
+import getAdjustedRow from '../helpers/getAdjustedRow';
 
 /**
  * Create a table
@@ -16,7 +17,7 @@ function createTable(
     rows: number,
     textGetter?: (row: number, column: number) => string
 ): Block {
-    const rowNodes = Range(0, rows)
+    let rowNodes = Range(0, rows)
         .map(i =>
             createRow(
                 opts,
@@ -25,13 +26,14 @@ function createTable(
             )
         )
         .toList();
-    const align = createAlign(columns);
+    const presetAlign = createAlign(columns);
+    rowNodes = rowNodes.map(row => getAdjustedRow(row, presetAlign));
 
     return Block.create({
         type: opts.typeTable,
         nodes: rowNodes,
         data: {
-            align
+            presetAlign
         }
     });
 }

--- a/lib/utils/createTable.js
+++ b/lib/utils/createTable.js
@@ -17,7 +17,8 @@ function createTable(
     rows: number,
     textGetter?: (row: number, column: number) => string
 ): Block {
-    let rowNodes = Range(0, rows)
+    const presetAlign = createAlign(columns);
+    const rowNodes = Range(0, rows)
         .map(i =>
             createRow(
                 opts,
@@ -25,9 +26,8 @@ function createTable(
                 textGetter ? textGetter.bind(null, i) : undefined
             )
         )
-        .toList();
-    const presetAlign = createAlign(columns);
-    rowNodes = rowNodes.map(row => getAdjustedRow(row, presetAlign));
+        .toList()
+        .map(row => getAdjustedRow(row, presetAlign));
 
     return Block.create({
         type: opts.typeTable,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,5 +1,6 @@
 import getPosition from './getPosition';
 import isSelectionInTable from './isSelectionInTable';
+import isSelectionOutOfTable from "./isSelectionOutOfTable";
 import TablePosition from './TablePosition';
 
 import createAlign from './createAlign';
@@ -10,9 +11,10 @@ import createTable from './createTable';
 export {
     getPosition,
     isSelectionInTable,
+    isSelectionOutOfTable,
     TablePosition,
     createAlign,
     createCell,
     createRow,
-    createTable
+    createTable,
 };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,6 +1,6 @@
 import getPosition from './getPosition';
 import isSelectionInTable from './isSelectionInTable';
-import isSelectionOutOfTable from "./isSelectionOutOfTable";
+import isSelectionOutOfTable from './isSelectionOutOfTable';
 import TablePosition from './TablePosition';
 
 import createAlign from './createAlign';
@@ -16,5 +16,5 @@ export {
     createAlign,
     createCell,
     createRow,
-    createTable,
+    createTable
 };

--- a/lib/utils/isSelectionOutOfTable.js
+++ b/lib/utils/isSelectionOutOfTable.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type { Value } from 'slate';
+import type Options from '../options';
+
+/**
+ * Is the selection in a table
+ */
+function isSelectionOutOfTable(opts: Options, value: Value): boolean {
+    if (!value.selection.startKey) return false;
+
+    const { startBlock, endBlock } = value;
+
+    // Only handle events in cells
+    return (startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell) 
+}
+
+export default isSelectionOutOfTable;

--- a/lib/utils/isSelectionOutOfTable.js
+++ b/lib/utils/isSelectionOutOfTable.js
@@ -12,7 +12,7 @@ function isSelectionOutOfTable(opts: Options, value: Value): boolean {
     const { startBlock, endBlock } = value;
 
     // Only handle events in cells
-    return (startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell) 
+    return startBlock.type !== opts.typeCell && endBlock.type !== opts.typeCell;
 }
 
 export default isSelectionOutOfTable;

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -63,13 +63,13 @@ function toValidateNode(rule: Rule): Validator {
 function noBlocksWithinCell(opts: Options): Rule {
     return {
         match(node) {
-            return node.kind == 'block' && node.type == opts.typeCell;
+            return node.object == 'block' && node.type == opts.typeCell;
         },
 
         // Find nested blocks
         validate(node) {
             const nestedBlocks = node.nodes.filter(
-                child => child.kind === 'block'
+                child => child.object === 'block'
             );
 
             return nestedBlocks.size > 0 ? nestedBlocks : null;
@@ -95,7 +95,7 @@ function cellsWithinTable(opts: Options): Rule {
     return {
         match(node) {
             return (
-                (node.kind === 'document' || node.kind === 'block') &&
+                (node.object === 'document' || node.object === 'block') &&
                 node.type !== opts.typeRow
             );
         },
@@ -133,7 +133,7 @@ function rowsWithinTable(opts: Options): Rule {
     return {
         match(node) {
             return (
-                (node.kind === 'document' || node.kind === 'block') &&
+                (node.object === 'document' || node.object === 'block') &&
                 node.type !== opts.typeTable
             );
         },

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -159,7 +159,7 @@ function rowsWithinTable(opts: Options): Rule {
                     {
                         type: opts.typeTable,
                         data: {
-                            align: createAlign(row.nodes.size)
+                            presetAlign: createAlign(row.nodes.size)
                         }
                     },
                     { normalize: false }
@@ -299,11 +299,13 @@ function tableContainAlignData(opts: Options): Rule {
         },
 
         validate(table) {
-            const align = table.data.get('align', []);
+            const presetAlign = table.data.get('presetAlign', []);
             const row = table.nodes.first();
             const columns = row.nodes.size;
 
-            return align.length == columns ? null : { align, columns };
+            return presetAlign.length == columns
+                ? null
+                : { presetAlign, columns };
         },
 
         /**
@@ -312,12 +314,15 @@ function tableContainAlignData(opts: Options): Rule {
         normalize(
             change,
             node,
-            { align, columns }: { align: string[], columns: number }
+            { presetAlign, columns }: { presetAlign: string[], columns: number }
         ) {
             return change.setNodeByKey(
                 node.key,
                 {
-                    data: node.data.set('align', createAlign(columns, align))
+                    data: node.data.set(
+                        'presetAlign',
+                        createAlign(columns, presetAlign)
+                    )
                 },
                 { normalize: false }
             );

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.2",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babelify": "^8.0.0",
@@ -43,9 +43,11 @@
     "watchify": "^3.7.0"
   },
   "scripts": {
-    "prepublish": "babel ./lib --out-dir ./dist",
+    "build:dist": "babel ./lib --out-dir ./dist",
+    "build:flow": "flow-copy-source -v ./lib/ ./dist/",
+    "prepublish": "npm run build:dist && npm run build:flow",
     "postpublish": "npm run deploy-example",
-    "lint": "eslint ./",
+    "lint": "./node_modules/.bin/eslint ./",
     "build-example": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react stage-0 ] ]",
     "watch-example": "watchify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react stage-0 ] ] -v",
     "serve-example": "http-server ./example/ -p 8080",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slate-edit-table",
   "description": "A Slate plugin to handle keyboard events in tables.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "Apache-2.0",
   "repository": "git://github.com/GitbookIO/slate-edit-table.git",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "slate": "^0.29.0"
+    "slate": ">0.29.0 <0.32.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -31,7 +31,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.31.7",
+    "slate": "^0.31.8",
     "slate-hyperscript": "^0.4.6",
     "slate-react": "^0.10.0",
     "watchify": "^3.7.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "slate": ">0.29.0 <0.32.0"
+    "slate": "^0.32.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -19,21 +19,27 @@
     "babel-preset-stage-0": "^6.24.1",
     "babelify": "^8.0.0",
     "browserify": "^13.3.0",
-    "eslint": "^4.10.0",
-    "eslint-config-gitbook": "2.0.3",
+    "eslint": "^4.15.0",
+    "eslint-config-gitbook": "^3.0.0",
+    "eslint-plugin-flowtype": "^2.41.0",
     "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-prettier": "^2.4.0",
+    "eslint-plugin-react": "^7.5.1",
     "expect": "^1.20.2",
     "flow-bin": "^0.57.3",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
-    "immutable": "^3.8.1",
+    "immutable": "^3.8.2",
     "mocha": "^3.0.1",
+    "prettier": "^1.9.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.31.8",
-    "slate-hyperscript": "^0.4.6",
-    "slate-react": "^0.10.0",
+    "slate": "^0.32.0",
+    "slate-hyperscript": "^0.5.0",
+    "slate-prop-types": "^0.4.17",
+    "slate-react": "^0.11.0",
     "watchify": "^3.7.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react": "^7.5.1",
     "expect": "^1.20.2",
     "flow-bin": "^0.57.3",
+    "flow-copy-source": "^1.2.1",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
     "immutable": "^3.8.2",

--- a/tests/backspace-clear-cells/expected.yaml
+++ b/tests/backspace-clear-cells/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/backspace-clear-cells/expected.yaml
+++ b/tests/backspace-clear-cells/expected.yaml
@@ -1,7 +1,7 @@
 
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -9,66 +9,66 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-clear-cells/input.yaml
+++ b/tests/backspace-clear-cells/input.yaml
@@ -1,72 +1,72 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   # Start selection here, expected result is text empty [
                   leaves:
                     - text: "Col 0, Row 1"
                   key: "anchor"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   # ] End selection here, expected result is text empty
                   leaves:
                     - text: "Col 0, Row 2"
                   key: "focus"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-collapsed/expected.yaml
+++ b/tests/backspace-collapsed/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-collapsed/input.yaml
+++ b/tests/backspace-collapsed/input.yaml
@@ -1,72 +1,72 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   # Start selection here, expected result is text empty [
                   leaves:
                     - text: "Col 0, Row 1"
                   key: "anchor"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   # ] End selection here, expected result is text empty
                   leaves:
                     - text: "Col 0, Row 2"
                   key: "focus"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-same-block/input.yaml
+++ b/tests/backspace-same-block/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
                   key: "anchor"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-start-cell/expected.yaml
+++ b/tests/backspace-start-cell/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/backspace-start-cell/input.yaml
+++ b/tests/backspace-start-cell/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
                   key: "anchor"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/get-fragment-in-different-table-normalized/change.js
+++ b/tests/get-fragment-in-different-table-normalized/change.js
@@ -1,0 +1,22 @@
+import expect from 'expect';
+import { Range } from 'slate';
+
+export default function(plugin, change) {
+    const { document } = change.value;
+    const anchorBlock = document.getDescendant('_anchor_');
+    const focusBlock = document.getDescendant('_focus_');
+    const range = Range.create()
+        .moveAnchorToStartOf(anchorBlock)
+        .moveAnchor(1)
+        .moveFocusToStartOf(focusBlock)
+        .moveFocus(1);
+
+    const fragment = plugin.utils.getFragmentAtRange(document, range);
+    const prevNodes = change.value.document.nodes;
+    expect(fragment.nodes.size === 3);
+    prevNodes.forEach((block, index) => {
+        const nextBlock = fragment.nodes.get(index);
+        change.replaceNodeByKey(block.key, nextBlock);
+    });
+    return change;
+}

--- a/tests/get-fragment-in-different-table-normalized/expected.yaml
+++ b/tests/get-fragment-in-different-table-normalized/expected.yaml
@@ -1,0 +1,40 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "ol 1, Row 2"
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: "Ebony is the cutest cat in the world"
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "C"

--- a/tests/get-fragment-in-different-table-normalized/input.yaml
+++ b/tests/get-fragment-in-different-table-normalized/input.yaml
@@ -1,0 +1,114 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: "Ebony is the cutest cat in the world"
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"

--- a/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/change.js
+++ b/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/change.js
@@ -1,0 +1,24 @@
+import expect from 'expect';
+import { Range } from 'slate';
+
+export default function(plugin, change) {
+    const { document } = change.value;
+    const anchorBlock = document.getDescendant('_anchor_');
+    const focusBlock = document.getDescendant('_focus_');
+    const range = Range.create()
+        .moveAnchorToStartOf(anchorBlock)
+        .moveAnchor(1)
+        .moveFocusToStartOf(focusBlock)
+        .moveFocus(1);
+
+    const fragment = plugin.utils.getFragmentAtRange(document, range);
+    expect(fragment.nodes.size).toEqual(3);
+    const prevNodes = change.value.document.nodes;
+    prevNodes.forEach((block, index) => {
+        change.removeNodeByKey(block.key);
+    });
+    fragment.nodes.forEach((block, index) => {
+        change.insertNodeByKey(change.value.document.key, index, block);
+    });
+    return change;
+}

--- a/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/expected.yaml
+++ b/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/expected.yaml
@@ -1,0 +1,40 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "ol 1, Row 2"
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: "Ebony is the cutest cat in the world"
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "C"

--- a/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/input.yaml
+++ b/tests/get-fragment-in-different-table-with-isVoid-blocks-on-edge/input.yaml
@@ -1,0 +1,124 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"
+    - object: block
+      type: image
+      isVoid: true
+      data:
+        - meow: "Ebony is the cutest cat in the world"
+    - object: block
+      type: paragraph
+      nodes:
+        - object: text
+          leaves:
+            - text: "Ebony is the cutest cat in the world"
+    - object: block
+      type: image
+      isVoid: true
+      data:
+        - miao: "Ebony is the cutest cat in the world"
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"

--- a/tests/get-fragment-in-same-cell/change.js
+++ b/tests/get-fragment-in-same-cell/change.js
@@ -1,0 +1,16 @@
+import { Range } from 'slate';
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { document } = change.value;
+    const cursorBlock = document.getDescendant('_cursor_');
+    const range = Range.create()
+        .moveAnchorToStartOf(cursorBlock)
+        .moveAnchor(1)
+        .moveFocusToEndOf(cursorBlock);
+
+    const fragment = plugin.utils.getFragmentAtRange(document, range);
+    expect(fragment.nodes.size).toEqual(1);
+    change.replaceNodeByKey(document.nodes.first().key, fragment.nodes.first());
+    return change;
+}

--- a/tests/get-fragment-in-same-cell/expected.yaml
+++ b/tests/get-fragment-in-same-cell/expected.yaml
@@ -1,0 +1,19 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+        custom: value
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_cursor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "ol 1, Row 1"

--- a/tests/get-fragment-in-same-cell/input.yaml
+++ b/tests/get-fragment-in-same-cell/input.yaml
@@ -1,0 +1,56 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+        custom: value
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              key: '_cursor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"

--- a/tests/get-fragment-in-same-row/change.js
+++ b/tests/get-fragment-in-same-row/change.js
@@ -1,0 +1,20 @@
+import expect from 'expect';
+import { Range } from 'slate';
+
+export default function(plugin, change) {
+    const { document } = change.value;
+    const anchorBlock = document.getDescendant('_anchor_');
+    const focusBlock = document.getDescendant('_focus_');
+    const range = Range.create()
+        .moveAnchorToStartOf(anchorBlock)
+        .moveAnchor(1)
+        .moveFocusToStartOf(focusBlock)
+        .moveFocus(1);
+
+    const fragment = plugin.utils.getFragmentAtRange(document, range);
+    expect(fragment.nodes.size).toEqual(1);
+    expect(fragment.object === 'document');
+    expect(fragment.text).toEqual('nchor Col 0, Row 1f');
+    change.replaceNodeByKey(document.nodes.first().key, fragment.nodes.first());
+    return change;
+}

--- a/tests/get-fragment-in-same-row/expected.yaml
+++ b/tests/get-fragment-in-same-row/expected.yaml
@@ -1,0 +1,26 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "nchor Col 0, Row 1"
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "f"

--- a/tests/get-fragment-in-same-row/input.yaml
+++ b/tests/get-fragment-in-same-row/input.yaml
@@ -1,0 +1,56 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "anchor Col 0, Row 1"
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "focus Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"

--- a/tests/get-fragment-in-same-table-normalized/change.js
+++ b/tests/get-fragment-in-same-table-normalized/change.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+import { Range } from 'slate';
+
+export default function(plugin, change) {
+    const { document } = change.value;
+    const anchorBlock = document.getDescendant('_anchor_');
+    const focusBlock = document.getDescendant('_focus_');
+    const range = Range.create()
+        .moveAnchorToStartOf(anchorBlock)
+        .moveAnchor(1)
+        .moveFocusToStartOf(focusBlock)
+        .moveFocus(1);
+
+    const fragment = plugin.utils.getFragmentAtRange(document, range);
+    expect(fragment.nodes.size).toEqual(1);
+    expect(fragment.object === 'document');
+    change.replaceNodeByKey(document.nodes.first().key, fragment.nodes.first());
+    return change;
+}

--- a/tests/get-fragment-in-same-table-normalized/expected.yaml
+++ b/tests/get-fragment-in-same-table-normalized/expected.yaml
@@ -1,0 +1,42 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"
+

--- a/tests/get-fragment-in-same-table-normalized/input.yaml
+++ b/tests/get-fragment-in-same-table-normalized/input.yaml
@@ -1,0 +1,56 @@
+document:
+  nodes:
+    - object: block
+      type: table
+      data:
+        presetAlign:
+          - center
+          - center
+      nodes:
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 0"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 0"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 1"
+            - object: block
+              type: table_cell
+              key: '_anchor_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 1"
+        - object: block
+          type: table_row
+          nodes:
+            - object: block
+              type: table_cell
+              key: '_focus_'
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 0, Row 2"
+            - object: block
+              type: table_cell
+              nodes:
+                - object: text
+                  leaves:
+                    - text: "Col 1, Row 2"

--- a/tests/get-position/input.yaml
+++ b/tests/get-position/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_' # start here
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/insert-column-at/expected.yaml
+++ b/tests/insert-column-at/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,72 +8,72 @@ document:
           - left
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/insert-column-at/expected.yaml
+++ b/tests/insert-column-at/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - left
           - center
@@ -19,6 +19,8 @@ document:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -40,6 +42,8 @@ document:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -61,6 +65,8 @@ document:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column-at/input.yaml
+++ b/tests/insert-column-at/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - center
       nodes:

--- a/tests/insert-column-at/input.yaml
+++ b/tests/insert-column-at/input.yaml
@@ -1,55 +1,55 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - center
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/insert-column-preserve-data/expected.yaml
+++ b/tests/insert-column-preserve-data/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -9,72 +9,72 @@ document:
           - center
         custom: value
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/insert-column-preserve-data/expected.yaml
+++ b/tests/insert-column-preserve-data/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - left
           - center
@@ -20,6 +20,8 @@ document:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -41,6 +43,8 @@ document:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -62,6 +66,8 @@ document:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column-preserve-data/input.yaml
+++ b/tests/insert-column-preserve-data/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,49 +8,49 @@ document:
           - center
         custom: value
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/insert-column-preserve-data/input.yaml
+++ b/tests/insert-column-preserve-data/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - center
           - center
         custom: value

--- a/tests/insert-column/expected.yaml
+++ b/tests/insert-column/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,72 +8,72 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/insert-column/expected.yaml
+++ b/tests/insert-column/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left
@@ -25,6 +25,8 @@ document:
                     - text: "Col 1, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -46,6 +48,8 @@ document:
                     - text: "Col 1, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -67,6 +71,8 @@ document:
                     - text: "Col 1, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-column/input.yaml
+++ b/tests/insert-column/input.yaml
@@ -1,55 +1,55 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/insert-column/input.yaml
+++ b/tests/insert-column/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
       nodes:

--- a/tests/insert-row/expected.yaml
+++ b/tests/insert-row/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -8,72 +8,72 @@ document:
               - left
               - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/insert-row/expected.yaml
+++ b/tests/insert-row/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left
@@ -55,18 +55,24 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-row/input.yaml
+++ b/tests/insert-row/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data: 
         presetAlign: 
@@ -8,46 +8,46 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/insert-row/input.yaml
+++ b/tests/insert-row/input.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/insert-table/expected.yaml
+++ b/tests/insert-table/expected.yaml
@@ -1,53 +1,53 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
               - left
               - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/insert-table/expected.yaml
+++ b/tests/insert-table/expected.yaml
@@ -9,7 +9,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
       nodes:
@@ -18,12 +18,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -33,12 +37,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: ""
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/insert-table/input.yaml
+++ b/tests/insert-table/input.yaml
@@ -1,10 +1,10 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "BeforeAfter"
 

--- a/tests/mod-enter-exit-table/expected.yaml
+++ b/tests/mod-enter-exit-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/mod-enter-exit-table/expected.yaml
+++ b/tests/mod-enter-exit-table/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -8,72 +8,72 @@ document:
               - left
               - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-          - kind: text
+          - object: text
             leaves:
               - text: ""

--- a/tests/mod-enter-exit-table/input.yaml
+++ b/tests/mod-enter-exit-table/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
                   key: "_cursor_"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/move-selection-by/expected.yaml
+++ b/tests/move-selection-by/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/move-selection-by/input.yaml
+++ b/tests/move-selection-by/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0" # move here
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_' # start here
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/move-selection/expected.yaml
+++ b/tests/move-selection/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/move-selection/input.yaml
+++ b/tests/move-selection/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_' # start here
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2" # move here

--- a/tests/on-shift-tab-first-cell/expected.yaml
+++ b/tests/on-shift-tab-first-cell/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,66 +8,66 @@ document:
           - left
           - left      
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-shift-tab-first-cell/expected.yaml
+++ b/tests/on-shift-tab-first-cell/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left      

--- a/tests/on-shift-tab-first-cell/input.yaml
+++ b/tests/on-shift-tab-first-cell/input.yaml
@@ -1,48 +1,48 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-shift-tab/expected.yaml
+++ b/tests/on-shift-tab/expected.yaml
@@ -1,47 +1,47 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-shift-tab/input.yaml
+++ b/tests/on-shift-tab/input.yaml
@@ -1,48 +1,48 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   key: '_cursor_'
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-tab-last-cell/expected.yaml
+++ b/tests/on-tab-last-cell/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,66 +8,66 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/on-tab-last-cell/expected.yaml
+++ b/tests/on-tab-last-cell/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/on-tab-last-cell/input.yaml
+++ b/tests/on-tab-last-cell/input.yaml
@@ -1,48 +1,48 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-tab-last-column/expected.yaml
+++ b/tests/on-tab-last-column/expected.yaml
@@ -1,47 +1,47 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-tab-last-column/input.yaml
+++ b/tests/on-tab-last-column/input.yaml
@@ -1,48 +1,48 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-tab/expected.yaml
+++ b/tests/on-tab/expected.yaml
@@ -1,47 +1,47 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves: 
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/on-tab/input.yaml
+++ b/tests/on-tab/input.yaml
@@ -1,48 +1,48 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   key: '_cursor_'
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/remove-column-first/expected.yaml
+++ b/tests/remove-column-first/expected.yaml
@@ -1,54 +1,54 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - right
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-column-first/expected.yaml
+++ b/tests/remove-column-first/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - right
           - center
       nodes:

--- a/tests/remove-column-first/input.yaml
+++ b/tests/remove-column-first/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-column-first/input.yaml
+++ b/tests/remove-column-first/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,67 +8,67 @@ document:
           - right
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-column-last-one/expected.yaml
+++ b/tests/remove-column-last-one/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/remove-column-last-one/expected.yaml
+++ b/tests/remove-column-last-one/expected.yaml
@@ -1,35 +1,35 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/remove-column-last-one/input.yaml
+++ b/tests/remove-column-last-one/input.yaml
@@ -1,36 +1,36 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"

--- a/tests/remove-column-last-one/input.yaml
+++ b/tests/remove-column-last-one/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/remove-column-preserve-data/expected.yaml
+++ b/tests/remove-column-preserve-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
           - left
           - center
       nodes:

--- a/tests/remove-column-preserve-data/expected.yaml
+++ b/tests/remove-column-preserve-data/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         custom: value
@@ -8,48 +8,48 @@ document:
           - left
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-column-preserve-data/input.yaml
+++ b/tests/remove-column-preserve-data/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         custom: value
@@ -9,67 +9,67 @@ document:
           - right
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-column-preserve-data/input.yaml
+++ b/tests/remove-column-preserve-data/input.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-column/expected.yaml
+++ b/tests/remove-column/expected.yaml
@@ -1,54 +1,54 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-column/expected.yaml
+++ b/tests/remove-column/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - center
       nodes:

--- a/tests/remove-column/input.yaml
+++ b/tests/remove-column/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - right
           - center

--- a/tests/remove-column/input.yaml
+++ b/tests/remove-column/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,67 +8,67 @@ document:
           - right
           - center
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-row-first/expected.yaml
+++ b/tests/remove-row-first/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,45 +8,45 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-row-first/expected.yaml
+++ b/tests/remove-row-first/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-row-first/input.yaml
+++ b/tests/remove-row-first/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-row-last-one/expected.yaml
+++ b/tests/remove-row-last-one/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,24 +8,24 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/remove-row-last-one/expected.yaml
+++ b/tests/remove-row-last-one/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-row-last-one/input.yaml
+++ b/tests/remove-row-last-one/input.yaml
@@ -1,27 +1,27 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"

--- a/tests/remove-row/expected.yaml
+++ b/tests/remove-row/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,45 +8,45 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-row/expected.yaml
+++ b/tests/remove-row/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/remove-row/input.yaml
+++ b/tests/remove-row/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-table-and-move-to-next-block/expected.yaml
+++ b/tests/remove-table-and-move-to-next-block/expected.yaml
@@ -1,16 +1,16 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
       # Removed table
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_after_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"

--- a/tests/remove-table-and-move-to-next-block/input.yaml
+++ b/tests/remove-table-and-move-to-next-block/input.yaml
@@ -1,82 +1,82 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_after_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"

--- a/tests/remove-table-and-move-to-previous-block/expected.yaml
+++ b/tests/remove-table-and-move-to-previous-block/expected.yaml
@@ -1,10 +1,10 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_after_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
       # Removed table

--- a/tests/remove-table-and-move-to-previous-block/input.yaml
+++ b/tests/remove-table-and-move-to-previous-block/input.yaml
@@ -1,76 +1,76 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_after_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-table-exit-with-none/input.yaml
+++ b/tests/remove-table-exit-with-none/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-table-exit-with-paragraph/expected.yaml
+++ b/tests/remove-table-exit-with-paragraph/expected.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes: 
-        - kind: text
+        - object: text
           leaves: 
-            - kind: leaf
+            - object: leaf
             - text: ""

--- a/tests/remove-table-exit-with-paragraph/input.yaml
+++ b/tests/remove-table-exit-with-paragraph/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/remove-table/expected.yaml
+++ b/tests/remove-table/expected.yaml
@@ -1,15 +1,15 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
       # Removed table
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"

--- a/tests/remove-table/input.yaml
+++ b/tests/remove-table/input.yaml
@@ -1,81 +1,81 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"

--- a/tests/schema-no-blocks-within-cells/expected.yaml
+++ b/tests/schema-no-blocks-within-cells/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-cells/expected.yaml
+++ b/tests/schema-no-blocks-within-cells/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,33 +9,33 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-                - kind: inline
+                - object: inline
                   type: link
                   nodes:
-                    - kind: text
+                    - object: text
                       leaves:
                       - text: "Row 1, Col 2"
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-cells/input.yaml
+++ b/tests/schema-no-blocks-within-cells/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-cells/input.yaml
+++ b/tests/schema-no-blocks-within-cells/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,30 +9,30 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: block
+                - object: block
                   type: paragraph
                   nodes:
-                    - kind: text
+                    - object: text
                       leaves:
                         - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: inline
+                - object: inline
                   type: link
                   nodes:
-                    - kind: text
+                    - object: text
                       leaves:
                         - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-rows/expected.yaml
+++ b/tests/schema-no-blocks-within-rows/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-rows/expected.yaml
+++ b/tests/schema-no-blocks-within-rows/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,24 +9,24 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-rows/input.yaml
+++ b/tests/schema-no-blocks-within-rows/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-rows/input.yaml
+++ b/tests/schema-no-blocks-within-rows/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,30 +9,30 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"
-            - kind: block
+            - object: block
               type: paragraph
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 4"

--- a/tests/schema-no-blocks-within-table/expected.yaml
+++ b/tests/schema-no-blocks-within-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-no-blocks-within-table/expected.yaml
+++ b/tests/schema-no-blocks-within-table/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,24 +9,24 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"

--- a/tests/schema-no-blocks-within-table/input.yaml
+++ b/tests/schema-no-blocks-within-table/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,30 +9,30 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"
-        - kind: block
+        - object: block
           type: paragraph
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "Row 1, Col 4"

--- a/tests/schema-no-blocks-within-table/input.yaml
+++ b/tests/schema-no-blocks-within-table/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-orphan-cells/expected.yaml
+++ b/tests/schema-orphan-cells/expected.yaml
@@ -1,33 +1,33 @@
 document:
   nodes:
     # A cell without surrounding row get wrapped in rows
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Cell 1"
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Cell 2"

--- a/tests/schema-orphan-cells/expected.yaml
+++ b/tests/schema-orphan-cells/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -19,7 +19,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-orphan-cells/input.yaml
+++ b/tests/schema-orphan-cells/input.yaml
@@ -1,15 +1,15 @@
 document:
   nodes:
     # A cell without surrounding row get wrapped in rows
-    - kind: block
+    - object: block
       type: table_cell
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Cell 1"
-    - kind: block
+    - object: block
       type: table_cell
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Cell 2"

--- a/tests/schema-rows-cells-within-tables/expected.yaml
+++ b/tests/schema-rows-cells-within-tables/expected.yaml
@@ -1,32 +1,32 @@
 document:
   nodes:
     # A row without surrounding table gets inserted within a table
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: text
+            - object: text
               leaves:
                 - text: "No table"
 
     # A cell without surrounding tr gets inserted within a table, and within a tr
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "No rows"

--- a/tests/schema-rows-cells-within-tables/expected.yaml
+++ b/tests/schema-rows-cells-within-tables/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -18,7 +18,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-rows-cells-within-tables/input.yaml
+++ b/tests/schema-rows-cells-within-tables/input.yaml
@@ -1,17 +1,17 @@
 document:
   nodes:
     # A row without surrounding table gets inserted within a table
-    - kind: block
+    - object: block
       type: table_row
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "No table"
 
     # A cell without surrounding tr gets inserted within a table, and within a tr
-    - kind: block
+    - object: block
       type: table_cell
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "No rows"

--- a/tests/schema-rows-require-same-columns-counts/expected.yaml
+++ b/tests/schema-rows-require-same-columns-counts/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-rows-require-same-columns-counts/expected.yaml
+++ b/tests/schema-rows-require-same-columns-counts/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,70 +9,70 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"
         # Row 2
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # Missing columns
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # Invalid columns replace by empty cell
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 3"

--- a/tests/schema-rows-require-same-columns-counts/input.yaml
+++ b/tests/schema-rows-require-same-columns-counts/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           presetAlign:
@@ -9,56 +9,56 @@ document:
               - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 3"
         # Row 2
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # Missing columns
-            - kind: text
+            - object: text
               leaves:
                 - text: "There is no columns here"
 
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"
             # Invalid column
-            - kind: block
+            - object: block
               type: invalid
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 3"

--- a/tests/schema-rows-require-same-columns-counts/input.yaml
+++ b/tests/schema-rows-require-same-columns-counts/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-          align:
+          presetAlign:
               - left
               - left
               - left

--- a/tests/schema-standard-table/expected.yaml
+++ b/tests/schema-standard-table/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
@@ -8,66 +8,66 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/schema-standard-table/expected.yaml
+++ b/tests/schema-standard-table/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
           - left
           - left

--- a/tests/schema-standard-table/input.yaml
+++ b/tests/schema-standard-table/input.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/schema-tables-contain-rows-empty/expected.yaml
+++ b/tests/schema-tables-contain-rows-empty/expected.yaml
@@ -1,18 +1,18 @@
 document:
   nodes:
     # At least one row
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""

--- a/tests/schema-tables-contain-rows-empty/expected.yaml
+++ b/tests/schema-tables-contain-rows-empty/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block

--- a/tests/schema-tables-contain-rows-empty/input.yaml
+++ b/tests/schema-tables-contain-rows-empty/input.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
     # At least one row
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "No rows"

--- a/tests/schema-tables-contain-rows-invalid/expected.yaml
+++ b/tests/schema-tables-contain-rows-invalid/expected.yaml
@@ -1,29 +1,29 @@
 document:
   nodes:
     # Only rows
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"

--- a/tests/schema-tables-contain-rows-invalid/expected.yaml
+++ b/tests/schema-tables-contain-rows-invalid/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         # Row 1

--- a/tests/schema-tables-contain-rows-invalid/input.yaml
+++ b/tests/schema-tables-contain-rows-invalid/input.yaml
@@ -1,36 +1,36 @@
 document:
   nodes:
     # Only rows
-    - kind: block
+    - object: block
       type: table
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
         # Not a row 2
-        - kind: block
+        - object: block
           type: default
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 2, Col 1"
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"

--- a/tests/schema-tables-contain-rows-mixed/expected.yaml
+++ b/tests/schema-tables-contain-rows-mixed/expected.yaml
@@ -1,45 +1,45 @@
 document:
   nodes:
     # At least one row
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: ""
     # Only rows
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
           - left
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"

--- a/tests/schema-tables-contain-rows-mixed/expected.yaml
+++ b/tests/schema-tables-contain-rows-mixed/expected.yaml
@@ -4,7 +4,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         - kind: block
@@ -20,7 +20,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
           - left
       nodes:
         # Row 1

--- a/tests/schema-tables-contain-rows-mixed/input.yaml
+++ b/tests/schema-tables-contain-rows-mixed/input.yaml
@@ -1,43 +1,43 @@
 document:
   nodes:
     # At least one row
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "No rows"
     # Only rows
-    - kind: block
+    - object: block
       type: table
       nodes:
         # Row 1
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 1, Col 1"
         # Not a row 2
-        - kind: block
+        - object: block
           type: default
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 2, Col 1"
         # Row 3
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Row 3, Col 1"

--- a/tests/selection-in-table.js/input.yaml
+++ b/tests/selection-in-table.js/input.yaml
@@ -1,28 +1,28 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   key: start
                   leaves:
                     - text: "Table 1"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   key: end
                   leaves:
                     - text: "Table 2"

--- a/tests/set-column-align-center-and-right/expected.yaml
+++ b/tests/set-column-align-center-and-right/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - center
             - right
       nodes:
@@ -12,12 +12,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -27,12 +31,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -42,12 +50,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-center-and-right/expected.yaml
+++ b/tests/set-column-align-center-and-right/expected.yaml
@@ -1,66 +1,66 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
             - center
             - right
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-center-and-right/input.yaml
+++ b/tests/set-column-align-center-and-right/input.yaml
@@ -1,56 +1,56 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign: 
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_1'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_2'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-center-and-right/input.yaml
+++ b/tests/set-column-align-center-and-right/input.yaml
@@ -2,6 +2,10 @@ document:
   nodes:
     - kind: block
       type: table
+      data:
+        presetAlign: 
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/set-column-align-left/expected.yaml
+++ b/tests/set-column-align-left/expected.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - left
             - left
       nodes:
@@ -13,12 +13,16 @@ document:
             # at argument is set to 1, so this column gets left aligned
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -28,12 +32,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
@@ -43,12 +51,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data: 
+                textAlign: left
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-left/expected.yaml
+++ b/tests/set-column-align-left/expected.yaml
@@ -1,67 +1,67 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
             - left
             - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # at argument is set to 1, so this column gets left aligned
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data: 
                 textAlign: left
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-left/input.yaml
+++ b/tests/set-column-align-left/input.yaml
@@ -1,57 +1,57 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         presetAlign:
             - center
             - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # at argument is set to 1, so this column gets left aligned
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # at argument is set to 1, so this column gets left aligned
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
             # at argument is set to 1, so this column gets left aligned
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-left/input.yaml
+++ b/tests/set-column-align-left/input.yaml
@@ -3,7 +3,7 @@ document:
     - kind: block
       type: table
       data:
-        align:
+        presetAlign:
             - center
             - left
       nodes:

--- a/tests/set-column-align-preserve-data/expected.yaml
+++ b/tests/set-column-align-preserve-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
         custom: value
-        align:
+        presetAlign:
             - center
             - right
       nodes:
@@ -13,12 +13,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 0"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -28,12 +32,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 1"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:
@@ -43,12 +51,16 @@ document:
           nodes:
             - kind: block
               type: table_cell
+              data:
+                textAlign: center
               nodes:
                 - kind: text
                   leaves:
                     - text: "Col 0, Row 2"
             - kind: block
               type: table_cell
+              data:
+                textAlign: right
               nodes:
                 - kind: text
                   leaves:

--- a/tests/set-column-align-preserve-data/expected.yaml
+++ b/tests/set-column-align-preserve-data/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         custom: value
@@ -8,60 +8,60 @@ document:
             - center
             - right
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: center
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               data:
                 textAlign: right
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-preserve-data/input.yaml
+++ b/tests/set-column-align-preserve-data/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
           custom: value
@@ -8,50 +8,50 @@ document:
               - left
               - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_1'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_2'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/set-column-align-preserve-data/input.yaml
+++ b/tests/set-column-align-preserve-data/input.yaml
@@ -4,7 +4,7 @@ document:
       type: table
       data:
           custom: value
-          align:
+          presetAlign:
               - left
               - left
       nodes:

--- a/tests/undo-insert-column/expected.yaml
+++ b/tests/undo-insert-column/expected.yaml
@@ -1,54 +1,54 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         align:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/undo-insert-column/input.yaml
+++ b/tests/undo-insert-column/input.yaml
@@ -1,55 +1,55 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data:
         align:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   key: '_cursor_'
                   leaves:
                     - text: "Col 1, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"

--- a/tests/undo-insert-row/expected.yaml
+++ b/tests/undo-insert-row/expected.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data: 
         presetAlign: 
@@ -8,45 +8,45 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/undo-insert-row/expected.yaml
+++ b/tests/undo-insert-row/expected.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/undo-insert-row/input.yaml
+++ b/tests/undo-insert-row/input.yaml
@@ -1,6 +1,6 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       data: 
         presetAlign: 
@@ -8,46 +8,46 @@ document:
           - left
           - left
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"

--- a/tests/undo-insert-row/input.yaml
+++ b/tests/undo-insert-row/input.yaml
@@ -2,6 +2,11 @@ document:
   nodes:
     - kind: block
       type: table
+      data: 
+        presetAlign: 
+          - left
+          - left
+          - left
       nodes:
         - kind: block
           type: table_row

--- a/tests/undo-insert-table/expected.yaml
+++ b/tests/undo-insert-table/expected.yaml
@@ -1,9 +1,9 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "BeforeAfter"
 

--- a/tests/undo-insert-table/input.yaml
+++ b/tests/undo-insert-table/input.yaml
@@ -1,10 +1,10 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       key: '_cursor_'
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "BeforeAfter"
 

--- a/tests/undo-remove-column/expected.yaml
+++ b/tests/undo-remove-column/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/undo-remove-column/input.yaml
+++ b/tests/undo-remove-column/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/undo-remove-row/expected.yaml
+++ b/tests/undo-remove-row/expected.yaml
@@ -1,68 +1,68 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/undo-remove-row/input.yaml
+++ b/tests/undo-remove-row/input.yaml
@@ -1,69 +1,69 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"

--- a/tests/undo-remove-table/expected.yaml
+++ b/tests/undo-remove-table/expected.yaml
@@ -1,80 +1,80 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"

--- a/tests/undo-remove-table/input.yaml
+++ b/tests/undo-remove-table/input.yaml
@@ -1,81 +1,81 @@
 document:
   nodes:
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "Before"
-    - kind: block
+    - object: block
       type: table
       nodes:
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 0"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 0"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               key: '_cursor_'
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 1"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 1"
-        - kind: block
+        - object: block
           type: table_row
           nodes:
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 0, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 1, Row 2"
-            - kind: block
+            - object: block
               type: table_cell
               nodes:
-                - kind: text
+                - object: text
                   leaves:
                     - text: "Col 2, Row 2"
-    - kind: block
+    - object: block
       type: paragraph
       nodes:
-        - kind: text
+        - object: text
           leaves:
             - text: "After"


### PR DESCRIPTION
Customized `getFragmentAtRange` for copy as fragment, works as:
1. If in same cell; copy as default
2. if in same row; copy as default
3. if in same table;
  - copy from valid start to valid end;
  - valid start is range start if range.start at first cell of row; otherwise the first cell of the row
  - valid end is similar in considering the end cell of the row
4. if in different table
  1. if start in table; try to copy from the valid start to end of table as fragment-1
  2. if end in table; try to copy from the table-start to the valid end as fragment-3
  3. copy between table as fragment-2
  4. return `merge( fragment-1, fragment-2, fragment-3)`

There is a potential bug I will not fix in recent days:
1. if there is a `void block` immediately before or after the table; the block will not be copied