### PR TITLE
Keep at least one Text Node in removeRow or removeColumn; Fix undo cu…

### DIFF
--- a/lib/changes/removeColumn.js
+++ b/lib/changes/removeColumn.js
@@ -1,5 +1,5 @@
 // @flow
-import { type Change } from 'slate';
+import { Text, type Change } from 'slate';
 import { List } from 'immutable';
 
 import { TablePosition } from '../utils';
@@ -8,7 +8,13 @@ import type Options from '../options';
 /**
  * Delete current column in a table
  */
-function removeColumn(opts: Options, change: Change, at: number): Change {
+function removeColumn(
+    opts: Options,
+    change: Change,
+    at: number,
+    editOptions: Object = {}
+): Change {
+    const { normalize = true, snapshot = true } = editOptions;
     const { value } = change;
     const { startBlock } = value;
 
@@ -17,6 +23,10 @@ function removeColumn(opts: Options, change: Change, at: number): Change {
 
     if (typeof at === 'undefined') {
         at = pos.getColumnIndex();
+    }
+
+    if (snapshot) {
+        change.snapshotSelection();
     }
 
     const rows = table.nodes;
@@ -38,14 +48,27 @@ function removeColumn(opts: Options, change: Change, at: number): Change {
         });
     } else {
         // If last column, clear text in cells instead
+        const { focusKey, anchorKey } = change.value.selection;
         rows.forEach(row => {
             row.nodes.forEach(cell => {
-                cell.nodes.forEach(node => {
-                    // We clear the texts in the cells
-                    change.removeNodeByKey(node.key);
-                });
+                // Remove all cell texts; But keep at least one Text Node, for preventing error of not finding DOM
+                const focusText = cell.getDescendant(focusKey);
+                const anchorText = cell.getDescendant(anchorKey);
+                cell = cell.set('nodes', List.of(Text.create('')));
+                change.replaceNodeByKey(cell.key, cell, { normalize: false });
+
+                // We should keep the cursor, but we can do it later
+                if (focusText) {
+                    change.moveFocusToStartOf(cell);
+                }
+                if (anchorText) {
+                    change.moveAnchorToStartOf(cell);
+                }
             });
         });
+    }
+    if (normalize) {
+        change.normalizeNodeByKey(table.key);
     }
 
     // Replace the table

--- a/lib/changes/removeRow.js
+++ b/lib/changes/removeRow.js
@@ -1,5 +1,6 @@
 // @flow
-import { type Change } from 'slate';
+import { Text, type Change } from 'slate';
+import { List } from 'immutable';
 
 import { TablePosition } from '../utils';
 import type Options from '../options';
@@ -7,7 +8,13 @@ import type Options from '../options';
 /**
  * Remove current row in a table. Clear it if last remaining row
  */
-function removeRow(opts: Options, change: Change, at: number): Change {
+function removeRow(
+    opts: Options,
+    change: Change,
+    at: number,
+    editOptions: Object = {}
+): Change {
+    const { snapshot = true, normalize = true } = editOptions;
     const { value } = change;
     const { startBlock } = value;
 
@@ -17,18 +24,36 @@ function removeRow(opts: Options, change: Change, at: number): Change {
     if (typeof at === 'undefined') {
         at = pos.getRowIndex();
     }
+    if (snapshot) {
+        change.snapshotSelection();
+    }
 
     const row = table.nodes.get(at);
     // Update table by removing the row
     if (pos.getHeight() > 1) {
-        change.removeNodeByKey(row.key);
+        change.removeNodeByKey(row.key, { normalize: false });
     } else {
-        // If last remaining row, clear it instead
+        // If last remaining row, clear all text content
+        // However, a Text Node should be left here to prevent error
+
+        const { focusKey, anchorKey } = change.value.selection;
         row.nodes.forEach(cell => {
-            cell.nodes.forEach(node => {
-                change.removeNodeByKey(node.key);
-            });
+            const focusText = cell.getDescendant(focusKey);
+            const anchorText = cell.getDescendant(anchorKey);
+            cell = cell.set('nodes', List.of(Text.create('')));
+            change.replaceNodeByKey(cell.key, cell, { normalize: false });
+
+            // We should keep the cursor, but we can do it later
+            if (focusText) {
+                change.moveFocusToStartOf(cell);
+            }
+            if (anchorText) {
+                change.moveAnchorToStartOf(cell);
+            }
         });
+    }
+    if (normalize) {
+        change.normalizeNodeByKey(table.key);
     }
 
     return change;

--- a/lib/changes/removeTable.js
+++ b/lib/changes/removeTable.js
@@ -7,7 +7,8 @@ import type Options from '../options';
 /**
  * Delete the whole table at position
  */
-function removeTable(opts: Options, change: Change): Change {
+function removeTable(opts: Options, change: Change, editOptions: Object = {}): Change {
+    const {normalize = true, snapshot= true} = editOptions
     const { value } = change;
     const { startBlock } = value;
 
@@ -40,14 +41,18 @@ function removeTable(opts: Options, change: Change): Change {
         }
     }
 
-    change.removeNodeByKey(table.key);
+    if (snapshot) {
+      change.snapshotSelection()
+    }
+
+    change.removeNodeByKey(table.key, {normalize});
     if (!nextFocusBlock) {
         return change;
     }
     if (shouldCollapseToEnd) {
-        change.collapseToEndOf(nextFocusBlock).focus();
+        change.collapseToEndOf(nextFocusBlock);
     } else {
-        change.collapseToStartOf(nextFocusBlock).focus();
+        change.collapseToStartOf(nextFocusBlock)
     }
     return change;
 }

--- a/tests/undo-remove-table/change.js
+++ b/tests/undo-remove-table/change.js
@@ -8,7 +8,8 @@ export default function(plugin, change) {
     toTest.call(plugin.changes.removeTable).undo();
 
     // Back to previous cursor position
-    expect(toTest.value.startBlock.text).toEqual('Before');
+    expect(toTest.value.startBlock.text).toEqual('Col 1, Row 1');
+    expect(toTest.value.startBlock.key).toEqual('_cursor_');
 
     return toTest;
 }


### PR DESCRIPTION
Fix Two bugs:
1. `removeRow` and `removeColumn` can have no Text Node in the cell, then it would cause `unable to find DOM by key` when select in the cell.
2. restore selection after undo, as discussed in https://github.com/GitbookIO/slate-edit-table/issues/40
