### PR TITLE
Switch back to prepublish for yarn compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build:dist": "babel ./lib --out-dir ./dist",
     "build:flow": "flow-copy-source -v ./lib/ ./dist/",
-    "prepublishOnly": "npm run build:dist && npm run build:flow",
+    "publish": "npm run build:dist && npm run build:flow",
     "postpublish": "npm run deploy-example",
     "lint": "eslint ./",
     "build-example": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ env react stage-0 ] ]",


### PR DESCRIPTION
It seems the `prepublishOnly` works in a different way with yarn than with npm.  I switch the `prepublishOnly` back to `prepublish` for https://github.com/GitbookIO/slate-edit-table/issues/64 and for https://github.com/GitbookIO/slate-edit-list/issues/62