### PR TITLE
Keyboard interactions for multi-blocks in table cells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - "stable"
+  - "9"

--- a/lib/changes/clearCell.js
+++ b/lib/changes/clearCell.js
@@ -1,5 +1,5 @@
 // @flow
-import { Range, type Change, type Block } from 'slate';
+import { Block, type Change } from 'slate';
 
 import type Options from '../options';
 
@@ -7,10 +7,18 @@ import type Options from '../options';
  * Clear the content of the given cell
  */
 function clearCell(opts: Options, change: Change, cell: Block): Change {
-    cell.nodes.forEach((node, index) => {
-        const range = Range.create().moveToRangeOf(cell);
-        change.deleteAtRange(range);
+    const newBlock = Block.create({ type: opts.typeContent });
+    const { nodes } = cell;
+
+    // Insert a new empty node
+    change.insertNodeByKey(cell.key, 0, newBlock, { normalize: false });
+
+    // Remove all previous nodes
+    nodes.forEach(node => {
+        change.removeNodeByKey(node.key);
     });
+
+    change.normalizeNodeByKey(cell.key);
 
     return change;
 }

--- a/lib/changes/moveSelectionBy.js
+++ b/lib/changes/moveSelectionBy.js
@@ -2,7 +2,6 @@
 import { type Change } from 'slate';
 
 import { TablePosition } from '../utils';
-import { moveSelection } from '../changes';
 import type Options from '../options';
 
 /**
@@ -27,13 +26,24 @@ function moveSelectionBy(
     const height = pos.getHeight();
 
     const [absX, absY] = normPos(x + colIndex, y + rowIndex, width, height);
+    const isGoingUp = y < 0;
 
     if (absX === -1) {
         // Out of table
         return change;
     }
 
-    return moveSelection(opts, change, absX, absY);
+    const { table } = pos;
+    const row = table.nodes.get(absY);
+    const cell = row.nodes.get(absX);
+
+    if (isGoingUp) {
+        change.collapseToEndOf(cell);
+    } else {
+        change.collapseToStartOf(cell);
+    }
+
+    return change;
 }
 
 /**

--- a/lib/handlers/onBackspace.js
+++ b/lib/handlers/onBackspace.js
@@ -39,15 +39,26 @@ function onBackspace(
     event.preventDefault();
 
     const { blocks } = value;
-    const getAncestorCell = node =>
-        node.type === opts.typeCell
-            ? node
-            : document.getClosest(node.key, a => a.type === opts.typeCell);
-    const cells = blocks.map(getAncestorCell).toSet();
+
+    // Get all cells that contains the selection
+    const cells = blocks
+        .map(
+            node =>
+                node.type === opts.typeCell
+                    ? node
+                    : document.getClosest(
+                          node.key,
+                          a => a.type === opts.typeCell
+                      )
+        )
+        .toSet();
+
+    // Clear all the selection
     cells.forEach(block => clearCell(opts, change, block));
 
-    // Clear selected cells
-    return change.collapseToStartOf(startBlock);
+    // Update the selection to avoid reset of selection
+    const updatedCell = change.value.document.getDescendant(cells.last().key);
+    return change.collapseToStartOf(updatedCell);
 }
 
 export default onBackspace;

--- a/lib/handlers/onBackspace.js
+++ b/lib/handlers/onBackspace.js
@@ -11,10 +11,20 @@ function onBackspace(
     opts: Options
 ): void | Change {
     const { value } = change;
-    const { startBlock, startOffset, isCollapsed, endBlock } = value;
+    const { startBlock, startOffset, isCollapsed, endBlock, document } = value;
 
-    // If a cursor is collapsed at the start of the block, do nothing
+    const cell = document.getParent(startBlock.key);
+    const startBlockIndex = cell.nodes.findIndex(
+        block => block.key == startBlock.key
+    );
+
+    // If a cursor is collapsed at the start of the first block, do nothing
     if (startOffset === 0 && isCollapsed) {
+        if (startBlockIndex > 0) {
+            // Normal deletion
+            return undefined;
+        }
+
         event.preventDefault();
         return change;
     }
@@ -28,13 +38,13 @@ function onBackspace(
     // we clear the content of the cells
     event.preventDefault();
 
-    const { blocks, document } = value;
+    const { blocks } = value;
     const getAncestorCell = node =>
         node.type === opts.typeCell
             ? node
             : document.getClosest(node.key, a => a.type === opts.typeCell);
     const cells = blocks.map(getAncestorCell).toSet();
-    cells.forEach(cell => clearCell(opts, change, cell));
+    cells.forEach(block => clearCell(opts, change, block));
 
     // Clear selected cells
     return change.collapseToStartOf(startBlock);

--- a/lib/handlers/onEnter.js
+++ b/lib/handlers/onEnter.js
@@ -15,6 +15,12 @@ function onEnter(
 ): void | Change {
     event.preventDefault();
 
+    if (event.shiftKey) {
+        return change
+            .splitBlock()
+            .setBlocks({ type: opts.typeContent, data: {} });
+    }
+
     return insertRow(opts, change);
 }
 

--- a/lib/handlers/onEnter.js
+++ b/lib/handlers/onEnter.js
@@ -2,6 +2,7 @@
 import { type Change } from 'slate';
 
 import type Options from '../options';
+import { TablePosition } from '../utils';
 import { insertRow } from '../changes';
 
 /**
@@ -14,6 +15,15 @@ function onEnter(
     opts: Options
 ): void | Change {
     event.preventDefault();
+    const { selection, document } = change.value;
+    const pos = TablePosition.create(opts, document, selection.startKey);
+
+    if (
+        !selection.hasFocusAtStartOf(pos.cell) &&
+        !selection.hasFocusAtEndOf(pos.cell)
+    ) {
+        return undefined;
+    }
 
     if (event.shiftKey) {
         return change

--- a/lib/handlers/onUpDown.js
+++ b/lib/handlers/onUpDown.js
@@ -23,11 +23,11 @@ function onUpDown(
         return undefined;
     }
 
-    if (direction < 0 && !pos.isTopOfCell()) {
+    if (direction === -1 && !pos.isTopOfCell()) {
         return undefined;
     }
 
-    if (direction > 0 && !pos.isBottomOfCell()) {
+    if (direction === +1 && !pos.isBottomOfCell()) {
         return undefined;
     }
 

--- a/lib/handlers/onUpDown.js
+++ b/lib/handlers/onUpDown.js
@@ -15,8 +15,6 @@ function onUpDown(
     const direction = event.key === 'ArrowUp' ? -1 : +1;
     const pos = TablePosition.create(opts, value.document, value.startKey);
 
-    console.log('onUpDown', pos);
-
     if (
         (pos.isFirstRow() && direction === -1) ||
         (pos.isLastRow() && direction === +1)

--- a/lib/handlers/onUpDown.js
+++ b/lib/handlers/onUpDown.js
@@ -15,6 +15,8 @@ function onUpDown(
     const direction = event.key === 'ArrowUp' ? -1 : +1;
     const pos = TablePosition.create(opts, value.document, value.startKey);
 
+    console.log('onUpDown', pos);
+
     if (
         (pos.isFirstRow() && direction === -1) ||
         (pos.isLastRow() && direction === +1)
@@ -22,9 +24,18 @@ function onUpDown(
         // Let the default behavior move out of the table
         return undefined;
     }
+
+    if (direction < 0 && !pos.isTopOfCell()) {
+        return undefined;
+    }
+
+    if (direction > 0 && !pos.isBottomOfCell()) {
+        return undefined;
+    }
+
     event.preventDefault();
 
-    moveSelectionBy(opts, change, 0, event.key === 'ArrowUp' ? -1 : +1);
+    moveSelectionBy(opts, change, 0, direction);
 
     return change;
 }

--- a/lib/utils/TablePosition.js
+++ b/lib/utils/TablePosition.js
@@ -1,5 +1,5 @@
 // @flow
-import { Record } from 'immutable';
+import { Record, List } from 'immutable';
 import { Block, type Document } from 'slate';
 
 import type Options from '../options';
@@ -7,7 +7,8 @@ import type Options from '../options';
 class TablePosition extends Record({
     tableBlock: null,
     rowBlock: null,
-    cellBlock: null
+    cellBlock: null,
+    contentBlock: null
 }) {
     // Block container for the table
     tableBlock: ?Block;
@@ -17,6 +18,9 @@ class TablePosition extends Record({
 
     // Block for current cell
     cellBlock: ?Block;
+
+    // Current content block in the cell
+    contentBlock: ?Block;
 
     /**
      * Create a new instance of a TablePosition from a Slate document
@@ -31,12 +35,24 @@ class TablePosition extends Record({
         const ancestors = document.getAncestors(key).push(node);
         const tableBlock = ancestors.findLast(p => p.type === opts.typeTable);
         const rowBlock = ancestors.findLast(p => p.type === opts.typeRow);
-        const cellBlock = ancestors.findLast(p => p.type === opts.typeCell);
+
+        const cellIndex = ancestors.findLastIndex(
+            p => p.type === opts.typeCell
+        );
+
+        // Skip all ancestors until the current cell
+        const cellsAndAfter =
+            cellIndex >= 0 ? ancestors.skip(cellIndex) : List();
+
+        // Take the cell and the inner content
+        const cellBlock = cellsAndAfter.first();
+        const contentBlock = cellsAndAfter.skip(1).first();
 
         return new TablePosition({
             tableBlock,
             rowBlock,
-            cellBlock
+            cellBlock,
+            contentBlock
         });
     }
 
@@ -80,6 +96,42 @@ class TablePosition extends Record({
      */
     isInTable(): boolean {
         return Boolean(this.tableBlock);
+    }
+
+    /**
+     * Check to see if this position is at the top of the cell.
+     */
+    isTopOfCell(): boolean {
+        const { contentBlock, cellBlock } = this;
+
+        if (!contentBlock || !cellBlock) {
+            return false;
+        }
+
+        const { nodes } = cellBlock;
+        const index = nodes.findIndex(block => block.key == contentBlock.key);
+
+        console.log('isTopOfCell', index);
+
+        return index == 0;
+    }
+
+    /**
+     * Check to see if this position is at the bottom of the cell.
+     */
+    isBottomOfCell(): boolean {
+        const { contentBlock, cellBlock } = this;
+
+        if (!contentBlock || !cellBlock) {
+            return false;
+        }
+
+        const { nodes } = cellBlock;
+        const index = nodes.findIndex(block => block.key == contentBlock.key);
+
+        console.log('isBottomOfCell', index);
+
+        return index == nodes.size - 1;
     }
 
     /**

--- a/lib/utils/TablePosition.js
+++ b/lib/utils/TablePosition.js
@@ -36,17 +36,11 @@ class TablePosition extends Record({
         const tableBlock = ancestors.findLast(p => p.type === opts.typeTable);
         const rowBlock = ancestors.findLast(p => p.type === opts.typeRow);
 
-        const cellIndex = ancestors.findLastIndex(
-            p => p.type === opts.typeCell
-        );
-
-        // Skip all ancestors until the current cell
-        const cellsAndAfter =
-            cellIndex >= 0 ? ancestors.skip(cellIndex) : List();
-
-        // Take the cell and the inner content
-        const cellBlock = cellsAndAfter.first();
-        const contentBlock = cellsAndAfter.skip(1).first();
+        const cellBlock = ancestors.findLast(p => p.type === opts.typeCell);
+        const contentBlock = ancestors
+            .skipUntil(ancestor => ancestor === cellBlock)
+            .skip(1)
+            .first();
 
         return new TablePosition({
             tableBlock,

--- a/lib/utils/TablePosition.js
+++ b/lib/utils/TablePosition.js
@@ -111,8 +111,6 @@ class TablePosition extends Record({
         const { nodes } = cellBlock;
         const index = nodes.findIndex(block => block.key == contentBlock.key);
 
-        console.log('isTopOfCell', index);
-
         return index == 0;
     }
 
@@ -128,8 +126,6 @@ class TablePosition extends Record({
 
         const { nodes } = cellBlock;
         const index = nodes.findIndex(block => block.key == contentBlock.key);
-
-        console.log('isBottomOfCell', index);
 
         return index == nodes.size - 1;
     }

--- a/tests/backspace-clear-cells-with-multiple-blocks/change.js
+++ b/tests/backspace-clear-cells-with-multiple-blocks/change.js
@@ -1,0 +1,18 @@
+export default function(plugin, change) {
+    const { value } = change;
+    const blockStart = value.document.getDescendant('anchor');
+    const blockEnd = value.document.getDescendant('focus');
+
+    const withCursor = change
+        .collapseToStartOf(blockStart)
+        .extendToEndOf(blockEnd);
+
+    return plugin.onKeyDown(
+        {
+            key: 'Backspace',
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        withCursor
+    );
+}

--- a/tests/backspace-clear-cells-with-multiple-blocks/expected.js
+++ b/tests/backspace-clear-cells-with-multiple-blocks/expected.js
@@ -1,0 +1,45 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                        <paragraph>Second block</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/backspace-clear-cells-with-multiple-blocks/input.js
+++ b/tests/backspace-clear-cells-with-multiple-blocks/input.js
@@ -1,0 +1,48 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell key="anchor">
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                        <paragraph>Second block</paragraph>
+                        <paragraph>Third block</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                        <paragraph>Second block</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell key="focus">
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                        <paragraph>Second block</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/enter-split-block/change.js
+++ b/tests/enter-split-block/change.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const blockStart = change.value.document.getDescendant('anchor');
+    const withCursor = change.collapseToEndOf(blockStart);
+
+    const result = plugin.onKeyDown(
+        {
+            key: 'Enter',
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        withCursor
+    );
+
+    expect(result.value.startBlock.type).toBe('paragraph');
+
+    return result;
+}

--- a/tests/enter-split-block/expected.js
+++ b/tests/enter-split-block/expected.js
@@ -1,0 +1,55 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/enter-split-block/input.js
+++ b/tests/enter-split-block/input.js
@@ -1,0 +1,44 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell key="anchor">
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/shift-enter-split-block/change.js
+++ b/tests/shift-enter-split-block/change.js
@@ -1,0 +1,20 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const blockStart = change.value.document.getDescendant('anchor');
+    const withCursor = change.collapseToEndOf(blockStart);
+
+    const result = plugin.onKeyDown(
+        {
+            key: 'Enter',
+            shiftKey: true,
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        withCursor
+    );
+
+    expect(result.value.startBlock.type).toBe('paragraph');
+
+    return result;
+}

--- a/tests/shift-enter-split-block/expected.js
+++ b/tests/shift-enter-split-block/expected.js
@@ -1,0 +1,45 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                        <paragraph />
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/shift-enter-split-block/input.js
+++ b/tests/shift-enter-split-block/input.js
@@ -1,0 +1,44 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell key="anchor">
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);


### PR DESCRIPTION
- [x] Split block when pressing <kbd>Shift+Enter</kbd> (Fix #71 )
- [x] Split block when pressing <kbd>Enter</kbd> inside the cell (Fix #3)
- [x] UP/DOWN doesn't move cursor across rows if there's a block after or before the cursor
- [x] <kbd>Backspace</kbd> should correctly let you delete a block
- [x] <kbd>Backspace</kbd> should correctly delete cells with multiple blocks (Fix #70)