### PR TITLE
Implement natural copy/paste with tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: node_js
 script:
   - yarn run test
   - yarn run lint
-  - yarn run flow
+  # - yarn run flow
 node_js:
   - "9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
 language: node_js
+script:
+  - yarn run test
+  - yarn run lint
+  - yarn run flow
 node_js:
   - "9"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ npm install slate-edit-table
 
 All these default features are configurable.
 
+### Copy/Paste behavior
+
+Here are how different cases of copy-paste are handled by the plugin:
+
+1. Copying the content of a single cell into another cell → The content of the first cell is pasted inside the second cell
+2. Copying the content of a single cell outside the table →  Just the content of the cell is pasted (not the table)
+3. Copying some content into a cell → The content is inserted inside the cell
+4. Copying multiple cells somewhere else inside the table → Rows containing the copied cells are inserted there
+5. Copying multiple cells outside the table → A new table is pasted, containing the copied cells.
+
 ## Simple Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here are how different cases of copy-paste are handled by the plugin:
 1. Copying the content of a single cell into another cell → The content of the first cell is pasted inside the second cell
 2. Copying the content of a single cell outside the table →  Just the content of the cell is pasted (not the table)
 3. Copying some content into a cell → The content is inserted inside the cell
-4. Copying multiple cells somewhere else inside the table → Rows containing the copied cells are inserted there
+4. Copying multiple cells somewhere else inside the table → The copied fragment of table is patched at the given position, overwritting cells and adding rows and columns if necessary.
 5. Copying multiple cells outside the table → A new table is pasted, containing the copied cells.
 
 ## Simple Usage

--- a/lib/changes/index.js
+++ b/lib/changes/index.js
@@ -1,4 +1,5 @@
 import insertTable from './insertTable';
+import insertTableFragmentAtRange from './insertTableFragmentAtRange';
 import insertRow from './insertRow';
 import removeRow from './removeRow';
 import insertColumn from './insertColumn';
@@ -13,6 +14,7 @@ import moveSelectionBy from './moveSelectionBy';
 
 export {
     insertTable,
+    insertTableFragmentAtRange,
     insertRow,
     removeRow,
     removeRowByKey,

--- a/lib/changes/insertTableFragmentAtRange.js
+++ b/lib/changes/insertTableFragmentAtRange.js
@@ -1,5 +1,4 @@
 // @flow
-import { List } from 'immutable';
 import { type Change, type Range, type Document } from 'slate';
 
 import { insertRow, insertColumn } from '../changes';
@@ -27,17 +26,6 @@ function insertTableFragmentAtRange(
     ) {
         throw new Error('Expected to insert a fragment containing one table');
     }
-
-    // If the range is expanded, delete it first.
-    // To do that, we reuse Slate.insertFragmentAtRange logic
-    // but with an empty fragment.
-    const emptyFragment = fragment.merge({
-        nodes: List()
-    });
-    change
-        .insertFragmentAtRange(range, emptyFragment)
-        // Make sure the selection is collapsed
-        .collapseToAnchor();
 
     const { value } = change;
     const targetPosition = TablePosition.create(

--- a/lib/changes/insertTableFragmentAtRange.js
+++ b/lib/changes/insertTableFragmentAtRange.js
@@ -1,0 +1,56 @@
+// @flow
+import { type Change, type Range, type Document } from 'slate';
+
+import { TablePosition } from '../utils';
+import type Options from '../options';
+
+/**
+ * Used when pasting a fragment of table into another one
+ */
+function insertTableFragmentAtRange(
+    opts: Options,
+    change: Change,
+    range: Range,
+    fragment: Document
+): Change {
+    const table = fragment.nodes.first();
+
+    if (
+        !(fragment.nodes.size === 1 && table && table.type === opts.typeTable)
+    ) {
+        throw new Error('Expected to insert a fragment containing one table');
+    }
+
+    // If the range is expanded, delete it first.
+    // To do that, we reuse Slate.insertFragmentAtRange logic
+    // but with an empty fragment.
+    const emptyFragment = fragment.merge({
+        nodes: fragment.nodes.slice(0, 0)
+    });
+    change
+        .insertFragmentAtRange(range, emptyFragment)
+        // Make sure the selection is collapsed
+        .collapseToAnchor();
+
+    const { value } = change;
+    const tablePosition = TablePosition.create(
+        opts,
+        value.document,
+        value.selection.startKey
+    );
+
+    const rows = table.nodes;
+
+    rows.forEach((row, rowIndex) => {
+        change.insertNodeByKey(
+            tablePosition.table.key,
+            tablePosition.getRowIndex() + rowIndex,
+            row,
+            { normalize: rowIndex === rows.size - 1 }
+        );
+    });
+
+    return change.collapseToEndOf(rows.last());
+}
+
+export default insertTableFragmentAtRange;

--- a/lib/changes/insertTableFragmentAtRange.js
+++ b/lib/changes/insertTableFragmentAtRange.js
@@ -1,6 +1,8 @@
 // @flow
+import { List } from 'immutable';
 import { type Change, type Range, type Document } from 'slate';
 
+import { insertRow, insertColumn } from '../changes';
 import { TablePosition } from '../utils';
 import type Options from '../options';
 
@@ -11,12 +13,17 @@ function insertTableFragmentAtRange(
     opts: Options,
     change: Change,
     range: Range,
+    // This fragment should contain only one table,
+    // with a valid number of cells
     fragment: Document
 ): Change {
-    const table = fragment.nodes.first();
-
+    const insertedTable = fragment.nodes.first();
     if (
-        !(fragment.nodes.size === 1 && table && table.type === opts.typeTable)
+        !(
+            fragment.nodes.size === 1 &&
+            insertedTable &&
+            insertedTable.type === opts.typeTable
+        )
     ) {
         throw new Error('Expected to insert a fragment containing one table');
     }
@@ -25,7 +32,7 @@ function insertTableFragmentAtRange(
     // To do that, we reuse Slate.insertFragmentAtRange logic
     // but with an empty fragment.
     const emptyFragment = fragment.merge({
-        nodes: fragment.nodes.slice(0, 0)
+        nodes: List()
     });
     change
         .insertFragmentAtRange(range, emptyFragment)
@@ -33,24 +40,64 @@ function insertTableFragmentAtRange(
         .collapseToAnchor();
 
     const { value } = change;
-    const tablePosition = TablePosition.create(
+    const targetPosition = TablePosition.create(
         opts,
         value.document,
         value.selection.startKey
     );
 
-    const rows = table.nodes;
+    const fragmentRows = insertedTable.nodes;
+    const fragmentHeight = fragmentRows.size;
+    const fragmentWidth = fragmentRows.first().nodes.size;
 
-    rows.forEach((row, rowIndex) => {
-        change.insertNodeByKey(
-            tablePosition.table.key,
-            tablePosition.getRowIndex() + rowIndex,
-            row,
-            { normalize: rowIndex === rows.size - 1 }
-        );
+    // Insert columns and rows to accomodate the incoming pasted cells
+    const missingWidth =
+        fragmentWidth +
+        targetPosition.getColumnIndex() -
+        targetPosition.getWidth();
+    const missingHeight =
+        fragmentHeight +
+        targetPosition.getRowIndex() -
+        targetPosition.getHeight();
+
+    if (missingWidth > 0) {
+        // Add columns
+        Array(missingWidth)
+            .fill()
+            .forEach(() => {
+                insertColumn(opts, change, targetPosition.getWidth());
+            });
+    }
+    if (missingHeight > 0) {
+        // Add rows
+        Array(missingHeight)
+            .fill()
+            .forEach(() => {
+                insertRow(opts, change, targetPosition.getHeight());
+            });
+    }
+
+    // Patch the inserted table over the target table, overwritting the cells
+    const existingTable = change.value.document.getDescendant(
+        targetPosition.table.key
+    );
+
+    fragmentRows.forEach((fragmentRow, fragmentRowIndex) => {
+        fragmentRow.nodes.forEach((newCell, fragmentColumnIndex) => {
+            const existingCell = existingTable.nodes
+                .get(targetPosition.getRowIndex() + fragmentRowIndex)
+                .nodes.get(
+                    targetPosition.getColumnIndex() + fragmentColumnIndex
+                );
+
+            change.replaceNodeByKey(existingCell.key, newCell, {
+                normalize: false
+            });
+        });
     });
 
-    return change.collapseToEndOf(rows.last());
+    const lastPastedCell = fragmentRows.last().nodes.last();
+    return change.collapseToEndOf(lastPastedCell);
 }
 
 export default insertTableFragmentAtRange;

--- a/lib/core.js
+++ b/lib/core.js
@@ -23,7 +23,8 @@ import {
     createTable,
     forEachCells,
     getCellsAtRow,
-    getCellsAtColumn
+    getCellsAtColumn,
+    getCopiedFragment
 } from './utils';
 import { schema, validateNode } from './validation';
 
@@ -55,7 +56,8 @@ function core(optionsParam: Options | OptionsFormat): Object {
             createTable: createTable.bind(null, opts),
             forEachCells: forEachCells.bind(null, opts),
             getCellsAtRow: getCellsAtRow.bind(null, opts),
-            getCellsAtColumn: getCellsAtColumn.bind(null, opts)
+            getCellsAtColumn: getCellsAtColumn.bind(null, opts),
+            getCopiedFragment: getCopiedFragment.bind(null, opts)
         },
 
         changes: {

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,6 +1,7 @@
 // @flow
 import {
     insertTable,
+    insertTableFragmentAtRange,
     insertRow,
     removeRow,
     insertColumn,
@@ -62,6 +63,10 @@ function core(optionsParam: Options | OptionsFormat): Object {
 
         changes: {
             insertTable: insertTable.bind(null, opts),
+            insertTableFragmentAtRange: insertTableFragmentAtRange.bind(
+                null,
+                opts
+            ),
             clearCell: clearCell.bind(null, opts),
             removeRowByKey: removeRowByKey.bind(null, opts),
             removeColumnByKey: removeColumnByKey.bind(null, opts),

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -4,5 +4,16 @@ import onTab from './onTab';
 import onBackspace from './onBackspace';
 import onUpDown from './onUpDown';
 import onKeyDown from './onKeyDown';
+import onCopy from './onCopy';
+import onPaste from './onPaste';
 
-export { onEnter, onModEnter, onTab, onBackspace, onUpDown, onKeyDown };
+export {
+    onEnter,
+    onModEnter,
+    onTab,
+    onBackspace,
+    onUpDown,
+    onKeyDown,
+    onCopy,
+    onPaste
+};

--- a/lib/handlers/onCopy.js
+++ b/lib/handlers/onCopy.js
@@ -1,0 +1,30 @@
+/* @flow */
+import { cloneFragment, type Editor } from 'slate-react';
+import { type Change } from 'slate';
+
+import type Options from '../options';
+import { getCopiedFragment } from '../utils';
+
+/**
+ *  Handle copying content of tables
+ */
+function onCopy(
+    // The plugin options
+    opts?: Options,
+    event: *,
+    change: Change,
+    editor: Editor
+): Object {
+    const copiedFragment = getCopiedFragment(opts, change.value);
+
+    if (!copiedFragment) {
+        // Default copy behavior
+        return null;
+    }
+
+    // Override default onCopy
+    cloneFragment(event, change.value, copiedFragment);
+    return true;
+}
+
+export default onCopy;

--- a/lib/handlers/onPaste.js
+++ b/lib/handlers/onPaste.js
@@ -1,0 +1,52 @@
+/* @flow */
+import { getEventTransfer, type Editor } from 'slate-react';
+import { Range, type Change } from 'slate';
+
+import type Options from '../options';
+import { isSelectionInTable, isRangeInTable } from '../utils';
+import { insertTableFragmentAtRange } from '../changes';
+
+/**
+ *  Handle pasting inside tables
+ */
+function onPaste(
+    // The plugin options
+    opts?: Options,
+    event: *,
+    change: Change,
+    editor: Editor
+): Object {
+    // Outside of tables, do not alter paste behavior
+    if (!isSelectionInTable(opts, change.value)) {
+        return undefined;
+    }
+
+    const transfer = getEventTransfer(event);
+    const { type, fragment } = transfer;
+
+    if (type != 'fragment' || fragment.nodes.isEmpty()) {
+        return null;
+    }
+
+    if (
+        !isRangeInTable(
+            opts,
+            fragment,
+            Range.create({
+                anchorKey: fragment.getFirstText().key,
+                focusKey: fragment.getLastText().key
+            })
+        )
+    ) {
+        return null;
+    }
+
+    return insertTableFragmentAtRange(
+        opts,
+        change,
+        change.value.selection,
+        fragment
+    );
+}
+
+export default onPaste;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,8 @@
 /* @flow */
-import { cloneFragment, type Editor } from 'slate-react';
-import { type Change } from 'slate';
 import Options, { type OptionsFormat } from './options';
 import type { TablePosition as _TablePosition } from './utils/TablePosition';
 import core from './core';
-import { onKeyDown } from './handlers';
+import { onKeyDown, onCopy, onPaste } from './handlers';
 
 /**
  *  Returns the full plugin object (behavior + rendering + schema)
@@ -20,20 +18,8 @@ function EditTable(
         ...corePlugin,
 
         onKeyDown: onKeyDown.bind(null, opts),
-        onCopy: (event: *, change: Change, editor: Editor) => {
-            const copiedFragment = corePlugin.utils.getCopiedFragment(
-                change.value
-            );
-
-            if (!copiedFragment) {
-                // Default copy behavior
-                return null;
-            }
-
-            // Override default onCopy
-            cloneFragment(event, change.value, copiedFragment);
-            return true;
-        }
+        onCopy: onCopy.bind(null, opts),
+        onPaste: onPaste.bind(null, opts)
     };
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,16 +21,17 @@ function EditTable(
 
         onKeyDown: onKeyDown.bind(null, opts),
         onCopy: (event: *, change: Change, editor: Editor) => {
-            const customFragment = corePlugin.utils.getCustomCopiedFragment(
+            const copiedFragment = corePlugin.utils.getCopiedFragment(
                 change.value
             );
 
-            if (!customFragment) {
+            if (!copiedFragment) {
+                // Default copy behavior
                 return null;
             }
 
             // Override default onCopy
-            cloneFragment(event, change.value, customFragment);
+            cloneFragment(event, change.value, copiedFragment);
             return true;
         }
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 /* @flow */
-
+import { cloneFragment, type Editor } from 'slate-react';
+import { type Change } from 'slate';
 import Options, { type OptionsFormat } from './options';
 import type { TablePosition as _TablePosition } from './utils/TablePosition';
 import core from './core';
@@ -18,7 +19,20 @@ function EditTable(
     return {
         ...corePlugin,
 
-        onKeyDown: onKeyDown.bind(null, opts)
+        onKeyDown: onKeyDown.bind(null, opts),
+        onCopy: (event: *, change: Change, editor: Editor) => {
+            const customFragment = corePlugin.utils.getCustomCopiedFragment(
+                change.value
+            );
+
+            if (!customFragment) {
+                return null;
+            }
+
+            // Override default onCopy
+            cloneFragment(event, change.value, customFragment);
+            return true;
+        }
     };
 }
 

--- a/lib/utils/TablePosition.js
+++ b/lib/utils/TablePosition.js
@@ -130,7 +130,7 @@ class TablePosition extends Record({
     getWidth(): number {
         const { table } = this;
         const rows = table.nodes;
-        const cells = rows.get(0).nodes;
+        const cells = rows.first().nodes;
 
         return cells.size;
     }

--- a/lib/utils/getCopiedFragment.js
+++ b/lib/utils/getCopiedFragment.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { type Value, type Document } from 'slate';
-import { Range } from 'immutable';
+import { List } from 'immutable';
 
 import type Options from '../options';
 import { isSelectionInTable, TablePosition, createCell } from '../utils';
@@ -44,16 +44,15 @@ function getCopiedFragment(opts: Options, value: Value): ?Document {
     const firstRow = table.nodes.first();
     const endRow = table.nodes.last();
 
-    const startPadding = new Range(0, startPosition.getColumnIndex())
-        .toList()
-        .map(() => createCell(opts));
+    const startPadding = List(Array(startPosition.getColumnIndex()).fill()).map(
+        () => createCell(opts)
+    );
 
-    const endPadding = new Range(
-        endPosition.getColumnIndex() + 1,
-        endPosition.getWidth()
-    )
-        .toList()
-        .map(() => createCell(opts));
+    const endPadding = List(
+        Array(
+            endPosition.getWidth() - (endPosition.getColumnIndex() + 1)
+        ).fill()
+    ).map(() => createCell(opts));
 
     return baseFragment.mapDescendants(node => {
         if (node === firstRow) {

--- a/lib/utils/getCopiedFragment.js
+++ b/lib/utils/getCopiedFragment.js
@@ -1,8 +1,9 @@
 /* @flow */
 import { type Value, type Document } from 'slate';
+import { Range } from 'immutable';
 
 import type Options from '../options';
-import { isSelectionInTable, TablePosition } from '../utils';
+import { isSelectionInTable, TablePosition, createCell } from '../utils';
 
 /*
  * Alters what is copied to the clipboard in the following cases:
@@ -15,30 +16,57 @@ function getCopiedFragment(opts: Options, value: Value): ?Document {
     }
 
     const { selection, document } = value;
-    const anchorPosition = TablePosition.create(
+    const startPosition = TablePosition.create(
         opts,
         document,
-        selection.anchorKey
+        selection.startKey
     );
-    const focusPosition = TablePosition.create(
-        opts,
-        document,
-        selection.focusKey
-    );
+    const endPosition = TablePosition.create(opts, document, selection.endKey);
 
-    if (focusPosition.cell !== anchorPosition.cell) {
-        return undefined;
-    }
-
-    // The selection is inside a single cell. Only copy the content of that cell
     const baseFragment = value.fragment;
 
-    const copiedCell = baseFragment
-        .getAncestors(baseFragment.getFirstText().key)
-        .findLast(n => n.type === opts.typeCell);
+    if (endPosition.cell === startPosition.cell) {
+        // The selection is inside a single cell. Only copy the content of that cell
+        const copiedCell = baseFragment
+            .getAncestors(baseFragment.getFirstText().key)
+            .findLast(n => n.type === opts.typeCell);
 
-    return baseFragment.merge({
-        nodes: copiedCell.nodes
+        return baseFragment.merge({
+            nodes: copiedCell.nodes
+        });
+    }
+
+    // The selection is a fragment of given table,
+    // we want to pad with empty cells to preserve a valid table
+    const table = baseFragment.nodes.first();
+    const firstRow = table.nodes.first();
+    const endRow = table.nodes.last();
+
+    const startPadding = new Range(0, startPosition.getColumnIndex())
+        .toList()
+        .map(() => createCell(opts));
+
+    const endPadding = new Range(
+        endPosition.getColumnIndex() + 1,
+        endPosition.getWidth()
+    )
+        .toList()
+        .map(() => createCell(opts));
+
+    return baseFragment.mapDescendants(node => {
+        if (node === firstRow) {
+            return firstRow.merge({
+                nodes: startPadding.concat(firstRow.nodes)
+            });
+        }
+
+        if (node === endRow) {
+            return endRow.merge({
+                nodes: endRow.nodes.concat(endPadding)
+            });
+        }
+
+        return node;
     });
 }
 

--- a/lib/utils/getCopiedFragment.js
+++ b/lib/utils/getCopiedFragment.js
@@ -6,14 +6,16 @@ import type Options from '../options';
 import { isSelectionInTable, TablePosition, createCell } from '../utils';
 
 /*
- * Alters what is copied to the clipboard in the following cases:
- * - Copying the content of a single cell
+ * Alters what is copied to the clipboard when copying a fragment of a table:
+ * - Copying the content of a single cell: just copy the content of the cell
+ * - Copying multiple cells: normalize the selection to copy a valid table
  */
 function getCopiedFragment(opts: Options, value: Value): ?Document {
     // Outside of tables, do not alter copy behavior
     if (!isSelectionInTable(opts, value)) {
         return undefined;
     }
+    // The selection is a fragment one table
 
     const { selection, document } = value;
     const startPosition = TablePosition.create(
@@ -23,6 +25,7 @@ function getCopiedFragment(opts: Options, value: Value): ?Document {
     );
     const endPosition = TablePosition.create(opts, document, selection.endKey);
 
+    // Fragment as it would be copied by Slate
     const baseFragment = value.fragment;
 
     if (endPosition.cell === startPosition.cell) {
@@ -36,8 +39,7 @@ function getCopiedFragment(opts: Options, value: Value): ?Document {
         });
     }
 
-    // The selection is a fragment of given table,
-    // we want to pad with empty cells to preserve a valid table
+    // We want to pad with empty cells to put a valid table into the clipboard
     const table = baseFragment.nodes.first();
     const firstRow = table.nodes.first();
     const endRow = table.nodes.last();

--- a/lib/utils/getCopiedFragment.js
+++ b/lib/utils/getCopiedFragment.js
@@ -8,7 +8,7 @@ import { isSelectionInTable, TablePosition } from '../utils';
  * Alters what is copied to the clipboard in the following cases:
  * - Copying the content of a single cell
  */
-function getCustomCopiedFragment(opts: Options, value: Value): ?Document {
+function getCopiedFragment(opts: Options, value: Value): ?Document {
     // Outside of tables, do not alter copy behavior
     if (!isSelectionInTable(opts, value)) {
         return undefined;
@@ -33,9 +33,13 @@ function getCustomCopiedFragment(opts: Options, value: Value): ?Document {
     // The selection is inside a single cell. Only copy the content of that cell
     const baseFragment = value.fragment;
 
+    const copiedCell = baseFragment
+        .getAncestors(baseFragment.getFirstText().key)
+        .findLast(n => n.type === opts.typeCell);
+
     return baseFragment.merge({
-        nodes: baseFragment.getDescendant(focusPosition.cell).nodes
-    })
+        nodes: copiedCell.nodes
+    });
 }
 
-export default getCustomCopiedFragment;
+export default getCopiedFragment;

--- a/lib/utils/getCopiedFragment.js
+++ b/lib/utils/getCopiedFragment.js
@@ -15,7 +15,7 @@ function getCopiedFragment(opts: Options, value: Value): ?Document {
     if (!isSelectionInTable(opts, value)) {
         return undefined;
     }
-    // The selection is a fragment one table
+    // else the selection is a fragment of one table
 
     const { selection, document } = value;
     const startPosition = TablePosition.create(

--- a/lib/utils/getCustomCopiedFragment.js
+++ b/lib/utils/getCustomCopiedFragment.js
@@ -1,0 +1,41 @@
+/* @flow */
+import { type Value, type Document } from 'slate';
+
+import type Options from '../options';
+import { isSelectionInTable, TablePosition } from '../utils';
+
+/*
+ * Alters what is copied to the clipboard in the following cases:
+ * - Copying the content of a single cell
+ */
+function getCustomCopiedFragment(opts: Options, value: Value): ?Document {
+    // Outside of tables, do not alter copy behavior
+    if (!isSelectionInTable(opts, value)) {
+        return undefined;
+    }
+
+    const { selection, document } = value;
+    const anchorPosition = TablePosition.create(
+        opts,
+        document,
+        selection.anchorKey
+    );
+    const focusPosition = TablePosition.create(
+        opts,
+        document,
+        selection.focusKey
+    );
+
+    if (focusPosition.cell !== anchorPosition.cell) {
+        return undefined;
+    }
+
+    // The selection is inside a single cell. Only copy the content of that cell
+    const baseFragment = value.fragment;
+
+    return baseFragment.merge({
+        nodes: baseFragment.getDescendant(focusPosition.cell).nodes
+    })
+}
+
+export default getCustomCopiedFragment;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3,6 +3,7 @@ import createRow from './createRow';
 import createTable from './createTable';
 import getPosition from './getPosition';
 import getPositionByKey from './getPositionByKey';
+import isRangeInTable from './isRangeInTable';
 import isSelectionInTable from './isSelectionInTable';
 import isSelectionOutOfTable from './isSelectionOutOfTable';
 import TablePosition from './TablePosition';
@@ -17,6 +18,7 @@ export {
     forEachCells,
     getCellsAtRow,
     getCellsAtColumn,
+    isRangeInTable,
     isSelectionInTable,
     isSelectionOutOfTable,
     TablePosition,

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -9,6 +9,7 @@ import TablePosition from './TablePosition';
 import forEachCells from './forEachCells';
 import getCellsAtRow from './getCellsAtRow';
 import getCellsAtColumn from './getCellsAtColumn';
+import getCopiedFragment from './getCopiedFragment';
 
 export {
     getPosition,
@@ -21,5 +22,6 @@ export {
     TablePosition,
     createCell,
     createRow,
-    createTable
+    createTable,
+    getCopiedFragment
 };

--- a/lib/utils/isRangeInTable.js
+++ b/lib/utils/isRangeInTable.js
@@ -1,0 +1,25 @@
+// @flow
+
+import type { Node, Range } from 'slate';
+
+import TablePosition from './TablePosition';
+import type Options from '../options';
+
+/**
+ * True if the given range is inside one table
+ */
+function isRangeInTable(opts: Options, node: Node, range: Range): boolean {
+    const { startKey, endKey } = range;
+    const startPosition = TablePosition.create(opts, node, startKey);
+    const endPosition = TablePosition.create(opts, node, endKey);
+
+    // Only handle events in tables
+    if (!startPosition.isInTable() || !endPosition.isInTable()) {
+        return false;
+    }
+
+    // Inside the same table
+    return startPosition.table === endPosition.table;
+}
+
+export default isRangeInTable;

--- a/lib/utils/isSelectionInTable.js
+++ b/lib/utils/isSelectionInTable.js
@@ -2,26 +2,15 @@
 
 import type { Value } from 'slate';
 
-import TablePosition from './TablePosition';
 import type Options from '../options';
+import isRangeInTable from './isRangeInTable';
 
 /**
  * Is the selection in a table
  */
 function isSelectionInTable(opts: Options, value: Value): boolean {
     if (!value.selection.startKey) return false;
-
-    const { startKey, endKey } = value;
-    const startPosition = TablePosition.create(opts, value.document, startKey);
-    const endPosition = TablePosition.create(opts, value.document, endKey);
-
-    // Only handle events in tables
-    if (!startPosition.isInTable() || !endPosition.isInTable()) {
-        return false;
-    }
-
-    // Inside the same table
-    return startPosition.table === endPosition.table;
+    return isRangeInTable(opts, value.document, value.selection);
 }
 
 export default isSelectionInTable;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "peerDependencies": {
     "immutable": "^3.8.1",
     "slate": "^0.34.5",
+    "slate-react": "^0.13.2",
     "slate-schema-violations": "^0.1.18"
   },
   "devDependencies": {
@@ -48,6 +49,7 @@
     "slate-hyperscript": "^0.5.20",
     "slate-react": "^0.13.2",
     "slate-schema-violations": "^0.1.18",
+    "slate-simulator": "^0.4.36",
     "watchify": "^3.7.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-prettier": "^2.4.0",
     "eslint-plugin-react": "^7.5.1",
     "expect": "^1.20.2",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.73.0",
     "flow-copy-source": "^1.2.1",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",

--- a/tests/all.js
+++ b/tests/all.js
@@ -3,7 +3,7 @@
 import expect from 'expect';
 import fs from 'fs';
 import path from 'path';
-import {Value, Schema, resetKeyGenerator} from 'slate';
+import { Value, Schema, resetKeyGenerator } from 'slate';
 import hyperprint from 'slate-hyperprint';
 import EditTable from '../lib';
 

--- a/tests/paste-content-into-cell/change.js
+++ b/tests/paste-content-into-cell/change.js
@@ -1,0 +1,22 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { value } = change;
+
+    // Copy the selection
+    let copiedFragment = plugin.utils.getCopiedFragment(value);
+    // Default copy in this case
+    expect(copiedFragment).toBeFalsy();
+
+    copiedFragment = value.fragment;
+
+    // Paste it
+    return change
+        .select({
+            anchorKey: 'cell',
+            anchorOffset: 0,
+            focusKey: 'cell',
+            focusOffset: 5
+        })
+        .insertFragment(copiedFragment);
+}

--- a/tests/paste-content-into-cell/expected.js
+++ b/tests/paste-content-into-cell/expected.js
@@ -1,0 +1,28 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Elsewhere, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+            <paragraph>Elsewhere</paragraph>
+        </document>
+    </value>
+);

--- a/tests/paste-content-into-cell/input.js
+++ b/tests/paste-content-into-cell/input.js
@@ -1,0 +1,34 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>
+                            <text key="cell">Col 1, Row 0</text>
+                        </paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+            <paragraph>
+                <text key="outside">
+                    <anchor />Elsewhere<focus />
+                </text>
+            </paragraph>
+        </document>
+    </value>
+);

--- a/tests/paste-empty-cell-into-cell/change.js
+++ b/tests/paste-empty-cell-into-cell/change.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { value } = change;
+
+    // Copy the selection
+    const copiedFragment = plugin.utils.getCopiedFragment(value);
+    expect(copiedFragment).toBeTruthy();
+
+    // Paste it
+    return change
+        .select({
+            anchorKey: 'paste-here',
+            anchorOffset: 7,
+            focusKey: 'paste-here',
+            focusOffset: 7
+        })
+        .insertFragment(copiedFragment);
+}

--- a/tests/paste-empty-cell-into-cell/expected.js
+++ b/tests/paste-empty-cell-into-cell/expected.js
@@ -1,0 +1,27 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-empty-cell-into-cell/input.js
+++ b/tests/paste-empty-cell-into-cell/input.js
@@ -1,0 +1,31 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            Col 0, <cursor />Row 0
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>
+                            <text key="paste-here">Col 1, Row 0</text>
+                        </paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-multiple-cells-at-same-position/change.js
+++ b/tests/paste-multiple-cells-at-same-position/change.js
@@ -9,7 +9,7 @@ export default function(plugin, change) {
     expect(copiedFragment).toBeTruthy();
 
     // Paste it
-    change.collapseToFocus();
+    change.collapseToAnchor();
 
     return plugin.changes.insertTableFragmentAtRange(
         change,

--- a/tests/paste-multiple-cells-at-same-position/expected.js
+++ b/tests/paste-multiple-cells-at-same-position/expected.js
@@ -7,14 +7,6 @@ export default (
             <table>
                 <table_row>
                     <table_cell>
-                        <paragraph>Col 0, Row 0</paragraph>
-                    </table_cell>
-                    <table_cell>
-                        <paragraph>Col 1, Row 0</paragraph>
-                    </table_cell>
-                </table_row>
-                <table_row>
-                    <table_cell>
                         <paragraph>Row 0</paragraph>
                     </table_cell>
                     <table_cell>

--- a/tests/paste-multiple-cells-at-same-position/input.js
+++ b/tests/paste-multiple-cells-at-same-position/input.js
@@ -7,7 +7,9 @@ export default (
             <table>
                 <table_row>
                     <table_cell>
-                        <paragraph>Col 0, Row 0</paragraph>
+                        <paragraph>
+                            Col 0, <anchor />Row 0
+                        </paragraph>
                     </table_cell>
                     <table_cell>
                         <paragraph>Col 1, Row 0</paragraph>
@@ -15,18 +17,12 @@ export default (
                 </table_row>
                 <table_row>
                     <table_cell>
-                        <paragraph>Row 0</paragraph>
+                        <paragraph>
+                            Col 0<focus />, Row 1
+                        </paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>Col 1, Row 0</paragraph>
-                    </table_cell>
-                </table_row>
-                <table_row>
-                    <table_cell>
-                        <paragraph>Col 0</paragraph>
-                    </table_cell>
-                    <table_cell>
-                        <paragraph />
+                        <paragraph>Col 1, Row 1</paragraph>
                     </table_cell>
                 </table_row>
             </table>

--- a/tests/paste-multiple-cells-into-table/change.js
+++ b/tests/paste-multiple-cells-into-table/change.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { value } = change;
+
+    // Copy the selection
+    const copiedFragment = plugin.utils.getCopiedFragment(value);
+    // Default copy in this case
+    expect(copiedFragment).toBeTruthy();
+
+    // Paste it
+    change.collapseToAnchor();
+
+    return plugin.changes.insertTableFragmentAtRange(
+        change,
+        change.value.selection,
+        copiedFragment
+    );
+}

--- a/tests/paste-multiple-cells-into-table/expected.js
+++ b/tests/paste-multiple-cells-into-table/expected.js
@@ -1,0 +1,43 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph />
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-multiple-cells-into-table/input.js
+++ b/tests/paste-multiple-cells-into-table/input.js
@@ -1,0 +1,31 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            Col 0, <anchor />Row 0
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            Col 0<focus />, Row 1
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-multiple-cells-outside/change.js
+++ b/tests/paste-multiple-cells-outside/change.js
@@ -4,11 +4,9 @@ export default function(plugin, change) {
     const { value } = change;
 
     // Copy the selection
-    let copiedFragment = plugin.utils.getCopiedFragment(value);
+    const copiedFragment = plugin.utils.getCopiedFragment(value);
     // Default copy in this case
-    expect(copiedFragment).toBeFalsy();
-
-    copiedFragment = value.fragment;
+    expect(copiedFragment).toBeTruthy();
 
     // Paste it
     return change

--- a/tests/paste-multiple-cells-outside/change.js
+++ b/tests/paste-multiple-cells-outside/change.js
@@ -1,0 +1,22 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { value } = change;
+
+    // Copy the selection
+    let copiedFragment = plugin.utils.getCopiedFragment(value);
+    // Default copy in this case
+    expect(copiedFragment).toBeFalsy();
+
+    copiedFragment = value.fragment;
+
+    // Paste it
+    return change
+        .select({
+            anchorKey: 'paste-here',
+            anchorOffset: 4,
+            focusKey: 'paste-here',
+            focusOffset: 4
+        })
+        .insertFragment(copiedFragment);
+}

--- a/tests/paste-multiple-cells-outside/expected.js
+++ b/tests/paste-multiple-cells-outside/expected.js
@@ -26,7 +26,7 @@ export default (
             <table>
                 <table_row>
                     <table_cell>
-                        <paragraph>Row 0</paragraph>
+                        <paragraph />
                     </table_cell>
                     <table_cell>
                         <paragraph>Col 1, Row 0</paragraph>
@@ -34,12 +34,10 @@ export default (
                 </table_row>
                 <table_row>
                     <table_cell>
-                        <paragraph>Col 0</paragraph>
+                        <paragraph>Col 0, Row 1</paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>
-                            <text />
-                        </paragraph>
+                        <paragraph />
                     </table_cell>
                 </table_row>
             </table>

--- a/tests/paste-multiple-cells-outside/expected.js
+++ b/tests/paste-multiple-cells-outside/expected.js
@@ -1,0 +1,49 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+            <paragraph>Else</paragraph>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>
+                            <text />
+                        </paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+            <paragraph>where</paragraph>
+        </document>
+    </value>
+);

--- a/tests/paste-multiple-cells-outside/input.js
+++ b/tests/paste-multiple-cells-outside/input.js
@@ -7,18 +7,18 @@ export default (
             <table>
                 <table_row>
                     <table_cell>
-                        <paragraph>
-                            Col 0, <anchor />Row 0
-                        </paragraph>
+                        <paragraph>Col 0, Row 0</paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>Col 1, Row 0</paragraph>
+                        <paragraph>
+                            <anchor />Col 1, Row 0
+                        </paragraph>
                     </table_cell>
                 </table_row>
                 <table_row>
                     <table_cell>
                         <paragraph>
-                            Col 0<focus />, Row 1
+                            Col 0, Row 1<focus />
                         </paragraph>
                     </table_cell>
                     <table_cell>

--- a/tests/paste-multiple-cells-outside/input.js
+++ b/tests/paste-multiple-cells-outside/input.js
@@ -1,0 +1,34 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            Col 0, <anchor />Row 0
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            Col 0<focus />, Row 1
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+            <paragraph>
+                <text key="paste-here">Elsewhere</text>
+            </paragraph>
+        </document>
+    </value>
+);

--- a/tests/paste-single-cell-into-cell/change.js
+++ b/tests/paste-single-cell-into-cell/change.js
@@ -1,0 +1,12 @@
+import Simulator from 'slate-simulator';
+import { BeforePlugin, AfterPlugin } from 'slate-react';
+
+export default function(plugin, change) {
+    const { value } = change;
+    const simulator = new Simulator({
+        plugins: [BeforePlugin, plugin, AfterPlugin],
+        value
+    });
+
+    return simulator.copy().value.change();
+}

--- a/tests/paste-single-cell-into-cell/change.js
+++ b/tests/paste-single-cell-into-cell/change.js
@@ -1,12 +1,19 @@
-import Simulator from 'slate-simulator';
-import { BeforePlugin, AfterPlugin } from 'slate-react';
+import expect from 'expect';
 
 export default function(plugin, change) {
     const { value } = change;
-    const simulator = new Simulator({
-        plugins: [BeforePlugin, plugin, AfterPlugin],
-        value
-    });
 
-    return simulator.copy().value.change();
+    // Copy the selection
+    const copiedFragment = plugin.utils.getCopiedFragment(value);
+    expect(copiedFragment).toBeTruthy();
+
+    // Paste it
+    return change
+        .select({
+            anchorKey: 'paste-here',
+            anchorOffset: 7,
+            focusKey: 'paste-here',
+            focusOffset: 7
+        })
+        .insertFragment(copiedFragment);
 }

--- a/tests/paste-single-cell-into-cell/expected.js
+++ b/tests/paste-single-cell-into-cell/expected.js
@@ -10,7 +10,7 @@ export default (
                         <paragraph>Col 0, Row 0</paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>Col 1, Row 0</paragraph>
+                        <paragraph>Col 1, Col 0, Row 0</paragraph>
                     </table_cell>
                 </table_row>
                 <table_row>

--- a/tests/paste-single-cell-into-cell/expected.js
+++ b/tests/paste-single-cell-into-cell/expected.js
@@ -21,14 +21,6 @@ export default (
                         <paragraph>Col 1, Row 1</paragraph>
                     </table_cell>
                 </table_row>
-                <table_row>
-                    <table_cell>
-                        <paragraph>Col 0, Row 2</paragraph>
-                    </table_cell>
-                    <table_cell>
-                        <paragraph>Col 1, Row 2</paragraph>
-                    </table_cell>
-                </table_row>
             </table>
         </document>
     </value>

--- a/tests/paste-single-cell-into-cell/expected.js
+++ b/tests/paste-single-cell-into-cell/expected.js
@@ -1,0 +1,35 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-single-cell-into-cell/input.js
+++ b/tests/paste-single-cell-into-cell/input.js
@@ -8,18 +8,20 @@ export default (
                 <table_row>
                     <table_cell>
                         <paragraph>
-                            <anchor />Col 0<focus />, Row 0
+                            <anchor />Col 0, <focus />Row 0
                         </paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>Col 1, Row 0</paragraph>
+                        <paragraph>
+                            <text key="paste-here">Col 1, Row 0</text>
+                        </paragraph>
                     </table_cell>
                 </table_row>
                 <table_row>
                     <table_cell>
                         <paragraph>Col 0, Row 1</paragraph>
                     </table_cell>
-                    <table_cell key="anchor">
+                    <table_cell>
                         <paragraph>Col 1, Row 1</paragraph>
                     </table_cell>
                 </table_row>

--- a/tests/paste-single-cell-into-cell/input.js
+++ b/tests/paste-single-cell-into-cell/input.js
@@ -1,0 +1,37 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>
+                            <anchor />Col 0<focus />, Row 0
+                        </paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell key="anchor">
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/paste-single-cell-outside/change.js
+++ b/tests/paste-single-cell-outside/change.js
@@ -1,0 +1,19 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const { value } = change;
+
+    // Copy the selection
+    const copiedFragment = plugin.utils.getCopiedFragment(value);
+    expect(copiedFragment).toBeTruthy();
+
+    // Paste it
+    return change
+        .select({
+            anchorKey: 'paste-here',
+            anchorOffset: 4,
+            focusKey: 'paste-here',
+            focusOffset: 4
+        })
+        .insertFragment(copiedFragment);
+}

--- a/tests/paste-single-cell-outside/expected.js
+++ b/tests/paste-single-cell-outside/expected.js
@@ -7,14 +7,10 @@ export default (
             <table>
                 <table_row>
                     <table_cell>
-                        <paragraph>
-                            <anchor />Col 0, <focus />Row 0
-                        </paragraph>
+                        <paragraph>Col 0, Row 0</paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>
-                            <text key="paste-here">Col 1, Row 0</text>
-                        </paragraph>
+                        <paragraph>Col 1, Row 0</paragraph>
                     </table_cell>
                 </table_row>
                 <table_row>
@@ -26,6 +22,7 @@ export default (
                     </table_cell>
                 </table_row>
             </table>
+            <paragraph>ElseCol 0where</paragraph>
         </document>
     </value>
 );

--- a/tests/paste-single-cell-outside/input.js
+++ b/tests/paste-single-cell-outside/input.js
@@ -8,13 +8,11 @@ export default (
                 <table_row>
                     <table_cell>
                         <paragraph>
-                            <anchor />Col 0, <focus />Row 0
+                            <anchor />Col 0<focus />, Row 0
                         </paragraph>
                     </table_cell>
                     <table_cell>
-                        <paragraph>
-                            <text key="paste-here">Col 1, Row 0</text>
-                        </paragraph>
+                        <paragraph>Col 1, Row 0</paragraph>
                     </table_cell>
                 </table_row>
                 <table_row>
@@ -26,6 +24,9 @@ export default (
                     </table_cell>
                 </table_row>
             </table>
+            <paragraph>
+                <text key="paste-here">Elsewhere</text>
+            </paragraph>
         </document>
     </value>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,9 +2366,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.73.0:
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
 
 flow-copy-source@^1.2.1:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4643,6 +4643,10 @@ slate-schema-violations@^0.1.18:
   version "0.1.18"
   resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.18.tgz#bc760e17dab85a613cd9a5399b98cbf867db0eb7"
 
+slate-simulator@^0.4.36:
+  version "0.4.59"
+  resolved "https://registry.yarnpkg.com/slate-simulator/-/slate-simulator-0.4.59.tgz#dfd5e6a6ffcafc0ce082619ae35634b745a37867"
+
 slate@^0.34.5:
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/slate/-/slate-0.34.5.tgz#4bc30dc300c924193d42371a7afcc168676f2798"


### PR DESCRIPTION
Fix #80 

This implements a smarter copy/paste behavior with tables. Here are how each case is handled:

1. Copying the content of a single cell into another cell 
  → The content of the first cell is pasted inside the second cell
2. Copying the content of a single cell outside the table
  →  Just the content of the cell is pasted (not the table)
3. Copying some content into a cell 
  → The content is inserted inside the cell
4. Copying multiple cells somewhere else inside the table
  → The copied fragment of table is patched at the given position, overwritting cells and adding rows and columns if necessary.
5. Copying multiple cells outside the table 
  → A new table is pasted, containing the copied cells.

This behavior is very much like the one from Google Docs and Dropbox paper.
