### PR TITLE
Fix backspace behavior when cursor is after an inline

### DIFF
--- a/lib/handlers/onBackspace.js
+++ b/lib/handlers/onBackspace.js
@@ -11,7 +11,7 @@ function onBackspace(
     opts: Options
 ): void | Change {
     const { value } = change;
-    const { startBlock, startOffset, isCollapsed, endBlock, document } = value;
+    const { startBlock, endBlock, selection, document } = value;
 
     const startCell = document.getClosest(startBlock.key, opts.isCell);
     const endCell = document.getClosest(endBlock.key, opts.isCell);
@@ -21,7 +21,7 @@ function onBackspace(
     );
 
     // If a cursor is collapsed at the start of the first block, do nothing
-    if (startOffset === 0 && isCollapsed && startBlockIndex === 0) {
+    if (startBlockIndex === 0 && selection.isAtStartOf(startBlock)) {
         if (startBlock.isVoid) {
             // Delete the block normally if it is a void block
             return undefined;

--- a/tests/backspace-after-inline/change.js
+++ b/tests/backspace-after-inline/change.js
@@ -1,0 +1,16 @@
+import expect from 'expect';
+
+export default function(plugin, change) {
+    const result = plugin.onKeyDown(
+        {
+            key: 'Backspace',
+            preventDefault() {},
+            stopPropagation() {}
+        },
+        change
+    );
+
+    expect(result).toBe(undefined);
+
+    return change;
+}

--- a/tests/backspace-after-inline/change.js
+++ b/tests/backspace-after-inline/change.js
@@ -1,15 +1,22 @@
 import expect from 'expect';
 
 export default function(plugin, change) {
+    let isDefaultPrevented = false;
     const result = plugin.onKeyDown(
         {
             key: 'Backspace',
-            preventDefault() {},
+            preventDefault() {
+                isDefaultPrevented = true;
+            },
             stopPropagation() {}
         },
         change
     );
 
+    // It shouldn't alter the default behavior...
+    expect(isDefaultPrevented).toBe(false);
+
+    // ...and let Slate do the work
     expect(result).toBe(undefined);
 
     return change;

--- a/tests/backspace-after-inline/input.js
+++ b/tests/backspace-after-inline/input.js
@@ -1,0 +1,47 @@
+/** @jsx hyperscript */
+import hyperscript from '../hyperscript';
+
+export default (
+    <value>
+        <document>
+            <table>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 0</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>
+                            Col 1, <link>Row</link>
+                            <cursor /> 0
+                        </paragraph>
+                    </table_cell>
+                    <table_cell key="anchor">
+                        <paragraph>Col 2, Row 0</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 1</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 1</paragraph>
+                    </table_cell>
+                </table_row>
+                <table_row>
+                    <table_cell>
+                        <paragraph>Col 0, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 1, Row 2</paragraph>
+                    </table_cell>
+                    <table_cell>
+                        <paragraph>Col 2, Row 2</paragraph>
+                    </table_cell>
+                </table_row>
+            </table>
+        </document>
+    </value>
+);

--- a/tests/backspace-after-inline/input.js
+++ b/tests/backspace-after-inline/input.js
@@ -1,4 +1,5 @@
 /** @jsx hyperscript */
+/* eslint-disable react/void-dom-elements-no-children */
 import hyperscript from '../hyperscript';
 
 export default (

--- a/tests/backspace-start-cell/change.js
+++ b/tests/backspace-start-cell/change.js
@@ -3,18 +3,24 @@ import expect from 'expect';
 export default function(plugin, change) {
     const { value } = change;
     const blockStart = value.document.getDescendant('anchor');
-
     const withCursor = change.collapseToStartOf(blockStart);
 
+    let isDefaultPrevented = false;
     const result = plugin.onKeyDown(
         {
             key: 'Backspace',
-            preventDefault() {},
+            preventDefault() {
+                isDefaultPrevented = true;
+            },
             stopPropagation() {}
         },
         withCursor
     );
 
+    // It should have prevented the default behavior...
+    expect(isDefaultPrevented).toBe(true);
+
+    // ...and left the change unchanged
     expect(result).toBe(change);
 
     return change;


### PR DESCRIPTION
The current implementation to check that the cursor is at the start of the cell's first block wasn't playing well with inlines. For example, `startOffset` is equal to `0` in the next scenario:

```
<table_cell>
  <paragraph>
    Here is the <bold>paragraph's</bold><cursor /> content.
  </paragraph>
</table_cell>
```

This PR replaces the logic with Slate's built-in `isAtStartOf` which does all of the required checks.